### PR TITLE
Support naming alias and trim prefix flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,21 @@ The tool can parse and convert OpenAPI documentation to NDC functions and proced
 - `anyOf`, `additionalProperties` and others -> `JSON`
 
 > Because NDC schema doesn't support union types it's impossible to convert dynamic schema to a static type. The `JSON` scalar represent as a dynamic JSON field and don't support nested selection.
+
+#### Naming convention
+
+Schema type names are usually matched with the referenced name. Anonymous type names will be generated from the URL path in PascalCase.
+
+If the `operationId` field exists in API operation, it will be used for functions or procedure name. Otherwise the operation name will be generated from URL path with camelCase format:
+
+```sh
+{http_method}{url_path_without_slash}
+
+# GET     /users/{id} => getUsersId
+# POST    /users      => postUsers
+# DELETE  /users      => deleteUsers
+```
+
+You can also change the method alias with `--method-alias=KEY=VALUE;...` flag, for example: `--method-alias=post=create;put=update`.
+
+If the URL path has a prefix such as `/api/v1/users`, you can trim that prefix with `--trim-prefix` flag.

--- a/command/convert.go
+++ b/command/convert.go
@@ -18,6 +18,7 @@ type ConvertCommandArguments struct {
 	Spec        string            `help:"The API specification of the file, is one of openapi3, openapi2" default:"openapi3"`
 	Format      string            `help:"The output format, is one of json, yaml. If the output is set, automatically detect the format in the output file extension" default:"json"`
 	Pure        bool              `help:"Return the pure NDC schema only" default:"false"`
+	TrimPrefix  string            `help:"Trim the prefix in URL, e.g. /v1"`
 	MethodAlias map[string]string `help:"Alias names for HTTP method. Used for prefix renaming, e.g. getUsers, postUser"`
 }
 
@@ -32,11 +33,15 @@ func ConvertToNDCSchema(args *ConvertCommandArguments, logger *slog.Logger) {
 
 	var result *schema.NDCRestSchema
 	var errs []error
+	options := &openapi.ConvertOptions{
+		MethodAlias: args.MethodAlias,
+		TrimPrefix:  args.TrimPrefix,
+	}
 	switch args.Spec {
 	case string(schema.OpenAPIv3Spec):
-		result, errs = openapi.OpenAPIv3ToNDCSchema(rawContent, args.MethodAlias)
+		result, errs = openapi.OpenAPIv3ToNDCSchema(rawContent, options)
 	case string(schema.OpenAPIv2Spec):
-		result, errs = openapi.OpenAPIv2ToNDCSchema(rawContent, args.MethodAlias)
+		result, errs = openapi.OpenAPIv2ToNDCSchema(rawContent, options)
 	default:
 		slog.Error(fmt.Sprintf("invalid spec %s, expected %+v", args.Spec, []schema.SchemaSpecType{schema.OpenAPIv3Spec, schema.OpenAPIv2Spec}))
 	}

--- a/command/convert.go
+++ b/command/convert.go
@@ -13,11 +13,12 @@ import (
 
 // ConvertCommandArguments represent available command arguments for the convert command
 type ConvertCommandArguments struct {
-	File   string `help:"File path needs to be converted." short:"f" required:""`
-	Output string `help:"The location where the ndc schema file will be generated. Print to stdout if not set" short:"o"`
-	Spec   string `help:"The API specification of the file, is one of openapi3, openapi2" default:"openapi3"`
-	Format string `help:"The output format, is one of json, yaml. If the output is set, automatically detect the format in the output file extension" default:"json"`
-	Pure   bool   `help:"Return the pure NDC schema only" default:"false"`
+	File        string            `help:"File path needs to be converted." short:"f" required:""`
+	Output      string            `help:"The location where the ndc schema file will be generated. Print to stdout if not set" short:"o"`
+	Spec        string            `help:"The API specification of the file, is one of openapi3, openapi2" default:"openapi3"`
+	Format      string            `help:"The output format, is one of json, yaml. If the output is set, automatically detect the format in the output file extension" default:"json"`
+	Pure        bool              `help:"Return the pure NDC schema only" default:"false"`
+	MethodAlias map[string]string `help:"Alias names for HTTP method. Used for prefix renaming, e.g. getUsers, postUser"`
 }
 
 // ConvertToNDCSchema converts to NDC REST schema from file
@@ -33,9 +34,9 @@ func ConvertToNDCSchema(args *ConvertCommandArguments, logger *slog.Logger) {
 	var errs []error
 	switch args.Spec {
 	case string(schema.OpenAPIv3Spec):
-		result, errs = openapi.OpenAPIv3ToNDCSchema(rawContent)
+		result, errs = openapi.OpenAPIv3ToNDCSchema(rawContent, args.MethodAlias)
 	case string(schema.OpenAPIv2Spec):
-		result, errs = openapi.OpenAPIv2ToNDCSchema(rawContent)
+		result, errs = openapi.OpenAPIv2ToNDCSchema(rawContent, args.MethodAlias)
 	default:
 		slog.Error(fmt.Sprintf("invalid spec %s, expected %+v", args.Spec, []schema.SchemaSpecType{schema.OpenAPIv3Spec, schema.OpenAPIv2Spec}))
 	}

--- a/openapi/testdata/jsonplaceholder/expected.json
+++ b/openapi/testdata/jsonplaceholder/expected.json
@@ -104,7 +104,7 @@
         }
       },
       "description": "Get comments for a specific post",
-      "name": "PostsIdComments",
+      "name": "getPostsIdComments",
       "result_type": {
         "element_type": {
           "name": "Comment",
@@ -261,7 +261,7 @@
         }
       },
       "description": "Get specific album",
-      "name": "AlbumsId",
+      "name": "getAlbumsId",
       "result_type": {
         "name": "Album",
         "type": "named"
@@ -289,7 +289,7 @@
         }
       },
       "description": "Get photos for a specific album",
-      "name": "AlbumsIdPhotos",
+      "name": "getAlbumsIdPhotos",
       "result_type": {
         "element_type": {
           "name": "Photo",
@@ -524,6 +524,19 @@
       },
       "description": "Get specific user",
       "name": "getUser",
+      "result_type": {
+        "name": "User",
+        "type": "named"
+      }
+    },
+    {
+      "request": {
+        "url": "/v1/test",
+        "method": "get"
+      },
+      "arguments": {},
+      "description": "Get test",
+      "name": "getTest",
       "result_type": {
         "name": "User",
         "type": "named"

--- a/openapi/testdata/jsonplaceholder/swagger.json
+++ b/openapi/testdata/jsonplaceholder/swagger.json
@@ -599,6 +599,27 @@
           }
         }
       }
+    },
+    "/v1/test": {
+      "get": {
+        "tags": ["test"],
+        "summary": "Get test",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "404": {
+            "description": "not found",
+            "schema": {
+              "$ref": "#/definitions/NotFoundError"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {

--- a/openapi/utils.go
+++ b/openapi/utils.go
@@ -23,12 +23,12 @@ const (
 	ContentTypeJSON   = "application/json"
 )
 
-func buildPathMethodName(apiPath string, method string) string {
+func buildPathMethodName(apiPath string, method string, methodAlias map[string]string) string {
 	encodedPath := utils.ToPascalCase(bracketRegexp.ReplaceAllString(strings.TrimLeft(apiPath, "/"), ""))
-	if method == "get" {
-		return encodedPath
+	if alias, ok := methodAlias[method]; ok {
+		method = alias
 	}
-	return utils.StringSliceToPascalCase([]string{method, encodedPath})
+	return utils.ToCamelCase(method + encodedPath)
 }
 
 func getSchemaRefTypeNameV2(name string) string {
@@ -85,4 +85,21 @@ func ParseTypeSchemaFromOpenAPISchema(input *base.Schema, typeName string) *sche
 	}
 
 	return ps
+}
+
+// getMethodAlias merge method alias map with default value
+func getMethodAlias(inputs ...map[string]string) map[string]string {
+	methodAlias := map[string]string{
+		"get":    "get",
+		"post":   "post",
+		"put":    "put",
+		"patch":  "patch",
+		"delete": "delete",
+	}
+	for _, input := range inputs {
+		for k, alias := range input {
+			methodAlias[k] = alias
+		}
+	}
+	return methodAlias
 }

--- a/openapi/utils.go
+++ b/openapi/utils.go
@@ -23,9 +23,30 @@ const (
 	ContentTypeJSON   = "application/json"
 )
 
-func buildPathMethodName(apiPath string, method string, methodAlias map[string]string) string {
+// ConvertOptions represent the common convert options for both OpenAPI v2 and v3
+type ConvertOptions struct {
+	MethodAlias map[string]string
+	TrimPrefix  string
+}
+
+func validateConvertOptions(opts *ConvertOptions) (*ConvertOptions, error) {
+	if opts == nil {
+		return &ConvertOptions{
+			MethodAlias: getMethodAlias(),
+		}, nil
+	}
+	return &ConvertOptions{
+		MethodAlias: getMethodAlias(opts.MethodAlias),
+		TrimPrefix:  opts.TrimPrefix,
+	}, nil
+}
+
+func buildPathMethodName(apiPath string, method string, options *ConvertOptions) string {
+	if options.TrimPrefix != "" {
+		apiPath = strings.TrimPrefix(apiPath, options.TrimPrefix)
+	}
 	encodedPath := utils.ToPascalCase(bracketRegexp.ReplaceAllString(strings.TrimLeft(apiPath, "/"), ""))
-	if alias, ok := methodAlias[method]; ok {
+	if alias, ok := options.MethodAlias[method]; ok {
 		method = alias
 	}
 	return utils.ToCamelCase(method + encodedPath)

--- a/openapi/v2.go
+++ b/openapi/v2.go
@@ -16,12 +16,16 @@ import (
 )
 
 type openAPIv2Converter struct {
-	schema      *rest.NDCRestSchema
-	methodAlias map[string]string
+	schema *rest.NDCRestSchema
+	*ConvertOptions
 }
 
 // OpenAPIv2ToNDCSchema converts OpenAPI v2 JSON bytes to NDC REST schema
-func OpenAPIv2ToNDCSchema(input []byte, methodAlias map[string]string) (*rest.NDCRestSchema, []error) {
+func OpenAPIv2ToNDCSchema(input []byte, options *ConvertOptions) (*rest.NDCRestSchema, []error) {
+	opts, err := validateConvertOptions(options)
+	if err != nil {
+		return nil, []error{err}
+	}
 	document, err := libopenapi.NewDocument(input)
 	if err != nil {
 		return nil, []error{err}
@@ -38,8 +42,8 @@ func OpenAPIv2ToNDCSchema(input []byte, methodAlias map[string]string) (*rest.ND
 	}
 
 	converter := &openAPIv2Converter{
-		schema:      rest.NewNDCRestSchema(),
-		methodAlias: getMethodAlias(methodAlias),
+		schema:         rest.NewNDCRestSchema(),
+		ConvertOptions: opts,
 	}
 	if docModel.Model.Info != nil {
 		converter.schema.Settings.Version = docModel.Model.Info.Version
@@ -80,7 +84,7 @@ func (oc *openAPIv2Converter) pathToNDCOperations(pathItem orderedmap.Pair[strin
 		itemGet := pathValue.Get
 		funcName := itemGet.OperationId
 		if funcName == "" {
-			funcName = buildPathMethodName(pathKey, "get", oc.methodAlias)
+			funcName = buildPathMethodName(pathKey, "get", oc.ConvertOptions)
 		}
 		resultType, err := oc.convertResponse(itemGet.Responses, []string{funcName, "Result"})
 		if err != nil {
@@ -154,7 +158,7 @@ func (oc *openAPIv2Converter) convertProcedureOperation(pathKey string, method s
 
 	procName := operation.OperationId
 	if procName == "" {
-		procName = buildPathMethodName(pathKey, method, oc.methodAlias)
+		procName = buildPathMethodName(pathKey, method, oc.ConvertOptions)
 	}
 
 	resultType, err := oc.convertResponse(operation.Responses, []string{procName, "Result"})

--- a/openapi/v2_test.go
+++ b/openapi/v2_test.go
@@ -38,7 +38,7 @@ func TestOpenAPIv2ToRESTSchema(t *testing.T) {
 			var expected schema.NDCRestSchema
 			assertNoError(t, json.Unmarshal(expectedBytes, &expected))
 
-			output, errs := OpenAPIv2ToNDCSchema(sourceBytes)
+			output, errs := OpenAPIv2ToNDCSchema(sourceBytes, nil)
 			if output == nil {
 				t.Error(errors.Join(errs...))
 				t.FailNow()
@@ -54,7 +54,7 @@ func TestOpenAPIv2ToRESTSchema(t *testing.T) {
 	}
 
 	t.Run("failure_empty", func(t *testing.T) {
-		_, err := OpenAPIv2ToNDCSchema([]byte(""))
+		_, err := OpenAPIv2ToNDCSchema([]byte(""), nil)
 		assertError(t, errors.Join(err...), "there is nothing in the spec, it's empty")
 	})
 }

--- a/openapi/v2_test.go
+++ b/openapi/v2_test.go
@@ -14,12 +14,16 @@ func TestOpenAPIv2ToRESTSchema(t *testing.T) {
 	testCases := []struct {
 		Name     string
 		Source   string
+		Options  *ConvertOptions
 		Expected string
 	}{
 		{
 			Name:     "petstore2",
 			Source:   "testdata/jsonplaceholder/swagger.json",
 			Expected: "testdata/jsonplaceholder/expected.json",
+			Options: &ConvertOptions{
+				TrimPrefix: "/v1",
+			},
 		},
 		{
 			Name:     "petstore2",
@@ -38,7 +42,7 @@ func TestOpenAPIv2ToRESTSchema(t *testing.T) {
 			var expected schema.NDCRestSchema
 			assertNoError(t, json.Unmarshal(expectedBytes, &expected))
 
-			output, errs := OpenAPIv2ToNDCSchema(sourceBytes, nil)
+			output, errs := OpenAPIv2ToNDCSchema(sourceBytes, tc.Options)
 			if output == nil {
 				t.Error(errors.Join(errs...))
 				t.FailNow()

--- a/openapi/v3_test.go
+++ b/openapi/v3_test.go
@@ -35,7 +35,7 @@ func TestOpenAPIv3ToRESTSchema(t *testing.T) {
 			var expected schema.NDCRestSchema
 			assertNoError(t, json.Unmarshal(expectedBytes, &expected))
 
-			output, errs := OpenAPIv3ToNDCSchema(sourceBytes)
+			output, errs := OpenAPIv3ToNDCSchema(sourceBytes, nil)
 			if output == nil {
 				t.Error(errors.Join(errs...))
 				t.FailNow()
@@ -51,7 +51,7 @@ func TestOpenAPIv3ToRESTSchema(t *testing.T) {
 	}
 
 	t.Run("failure_empty", func(t *testing.T) {
-		_, err := OpenAPIv3ToNDCSchema([]byte(""))
+		_, err := OpenAPIv3ToNDCSchema([]byte(""), nil)
 		assertError(t, errors.Join(err...), "there is nothing in the spec, it's empty")
 	})
 }

--- a/utils/string.go
+++ b/utils/string.go
@@ -7,6 +7,15 @@ import (
 
 var nonAlphaDigitRegex = regexp.MustCompile(`[^\w]+`)
 
+// ToCamelCase convert a string to camelCase
+func ToCamelCase(input string) string {
+	pascalCase := ToPascalCase(input)
+	if pascalCase == "" {
+		return pascalCase
+	}
+	return strings.ToLower(pascalCase[:1]) + pascalCase[1:]
+}
+
 // ToPascalCase convert a string to PascalCase
 func ToPascalCase(input string) string {
 	if input == "" {


### PR DESCRIPTION
Support new flags to customize the method prefix and trim URL prefix

```sh
      --trim-prefix=STRING            Trim the prefix in URL, e.g. /v1
      --method-alias=KEY=VALUE;...    Alias names for HTTP method. Used for prefix renaming, e.g. getUsers, postUser
```