### PR TITLE
support request body and custom scalar types

### DIFF
--- a/command/convert.go
+++ b/command/convert.go
@@ -49,9 +49,9 @@ func ConvertToNDCSchema(args *ConvertCommandArguments, logger *slog.Logger) erro
 		Logger:      logger,
 	}
 	switch args.Spec {
-	case string(schema.OpenAPIv3Spec):
+	case string(schema.OpenAPIv3Spec), string(schema.OAS3Spec):
 		result, errs = openapi.OpenAPIv3ToNDCSchema(rawContent, options)
-	case string(schema.OpenAPIv2Spec):
+	case string(schema.OpenAPIv2Spec), string(schema.OAS2Spec):
 		result, errs = openapi.OpenAPIv2ToNDCSchema(rawContent, options)
 	default:
 		err := fmt.Errorf("invalid spec %s, expected %+v", args.Spec, []schema.SchemaSpecType{schema.OpenAPIv3Spec, schema.OpenAPIv2Spec})

--- a/openapi/testdata/jsonplaceholder/expected.json
+++ b/openapi/testdata/jsonplaceholder/expected.json
@@ -1,7 +1,9 @@
 {
   "settings": {
     "servers": [
-      { "url": "{{SERVER_URL:-https://jsonplaceholder.typicode.com}}" }
+      {
+        "url": "{{SERVER_URL:-https://jsonplaceholder.typicode.com}}"
+      }
     ],
     "version": "1.0.0"
   },
@@ -15,12 +17,20 @@
           {
             "name": "id",
             "in": "query",
-            "required": false
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            }
           },
           {
             "name": "userId",
             "in": "query",
-            "required": false
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            }
           }
         ]
       },
@@ -64,7 +74,11 @@
           {
             "name": "id",
             "in": "path",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "nullable": false
+            }
           }
         ]
       },
@@ -92,7 +106,11 @@
           {
             "name": "id",
             "in": "path",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "nullable": false
+            }
           }
         ]
       },
@@ -123,12 +141,20 @@
           {
             "name": "id",
             "in": "query",
-            "required": false
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            }
           },
           {
             "name": "postId",
             "in": "query",
-            "required": false
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            }
           }
         ]
       },
@@ -172,7 +198,11 @@
           {
             "name": "id",
             "in": "path",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "nullable": false
+            }
           }
         ]
       },
@@ -200,12 +230,20 @@
           {
             "name": "id",
             "in": "query",
-            "required": false
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            }
           },
           {
             "name": "userId",
             "in": "query",
-            "required": false
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            }
           }
         ]
       },
@@ -249,7 +287,11 @@
           {
             "name": "id",
             "in": "path",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "nullable": false
+            }
           }
         ]
       },
@@ -277,7 +319,11 @@
           {
             "name": "id",
             "in": "path",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "nullable": false
+            }
           }
         ]
       },
@@ -308,12 +354,20 @@
           {
             "name": "id",
             "in": "query",
-            "required": false
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            }
           },
           {
             "name": "albumId",
             "in": "query",
-            "required": false
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            }
           }
         ]
       },
@@ -357,7 +411,11 @@
           {
             "name": "id",
             "in": "path",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "nullable": false
+            }
           }
         ]
       },
@@ -385,12 +443,20 @@
           {
             "name": "id",
             "in": "query",
-            "required": false
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            }
           },
           {
             "name": "userId",
             "in": "query",
-            "required": false
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            }
           }
         ]
       },
@@ -434,7 +500,11 @@
           {
             "name": "id",
             "in": "path",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "nullable": false
+            }
           }
         ]
       },
@@ -462,12 +532,20 @@
           {
             "name": "id",
             "in": "query",
-            "required": false
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            }
           },
           {
             "name": "email",
             "in": "query",
-            "required": false
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "nullable": true
+            }
           }
         ]
       },
@@ -511,7 +589,11 @@
           {
             "name": "id",
             "in": "path",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "nullable": false
+            }
           }
         ]
       },
@@ -552,7 +634,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -570,7 +652,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -601,7 +683,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -619,7 +701,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -632,7 +714,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -641,7 +723,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -650,7 +732,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "String",
+              "name": "URI",
               "type": "named"
             }
           }
@@ -668,7 +750,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "String",
+              "name": "URI",
               "type": "named"
             }
           }
@@ -690,7 +772,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -708,7 +790,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -730,7 +812,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -748,7 +830,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -788,7 +870,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -939,19 +1021,13 @@
       "request": {
         "url": "/posts",
         "method": "post",
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "type": "JSON"
-            }
+        "requestBody": {
+          "required": true,
+          "contentType": "application/json",
+          "schema": {
+            "type": "JSON"
           }
-        ]
+        }
       },
       "arguments": {
         "body": {
@@ -973,24 +1049,23 @@
       "request": {
         "url": "/posts/{id}",
         "method": "put",
-        "headers": {
-          "Content-Type": "application/json"
-        },
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "required": true
-          },
-          {
-            "name": "body",
-            "in": "body",
             "required": true,
             "schema": {
-              "type": "JSON"
+              "type": "integer",
+              "nullable": false
             }
           }
-        ]
+        ],
+        "requestBody": {
+          "required": true,
+          "schema": {
+            "type": "JSON"
+          }
+        }
       },
       "arguments": {
         "body": {
@@ -1019,24 +1094,23 @@
       "request": {
         "url": "/posts/{id}",
         "method": "patch",
-        "headers": {
-          "Content-Type": "application/json"
-        },
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "required": true
-          },
-          {
-            "name": "body",
-            "in": "body",
             "required": true,
             "schema": {
-              "type": "JSON"
+              "type": "integer",
+              "nullable": false
             }
           }
-        ]
+        ],
+        "requestBody": {
+          "required": true,
+          "schema": {
+            "type": "JSON"
+          }
+        }
       },
       "arguments": {
         "body": {
@@ -1065,14 +1139,15 @@
       "request": {
         "url": "/posts/{id}",
         "method": "delete",
-        "headers": {
-          "Content-Type": "application/json"
-        },
         "parameters": [
           {
             "name": "id",
             "in": "path",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "nullable": false
+            }
           }
         ]
       },
@@ -1097,22 +1172,45 @@
     }
   ],
   "scalar_types": {
+    "BigInt": {
+      "aggregate_functions": {},
+      "comparison_operators": {}
+    },
     "Boolean": {
       "aggregate_functions": {},
       "comparison_operators": {},
-      "representation": { "type": "boolean" }
+      "representation": {
+        "type": "boolean"
+      }
     },
     "Int": {
       "aggregate_functions": {},
       "comparison_operators": {},
-      "representation": { "type": "integer" }
+      "representation": {
+        "type": "integer"
+      }
     },
-    "JSON": { "aggregate_functions": {}, "comparison_operators": {} },
-    "NotFoundError": { "aggregate_functions": {}, "comparison_operators": {} },
+    "JSON": {
+      "aggregate_functions": {},
+      "comparison_operators": {}
+    },
+    "NotFoundError": {
+      "aggregate_functions": {},
+      "comparison_operators": {}
+    },
     "String": {
       "aggregate_functions": {},
       "comparison_operators": {},
-      "representation": { "type": "string" }
+      "representation": {
+        "type": "string"
+      }
+    },
+    "URI": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "string"
+      }
     }
   }
 }

--- a/openapi/testdata/jsonplaceholder/expected.json
+++ b/openapi/testdata/jsonplaceholder/expected.json
@@ -1025,7 +1025,7 @@
           "required": true,
           "contentType": "application/json",
           "schema": {
-            "type": "JSON"
+            "type": "Post"
           }
         }
       },
@@ -1063,7 +1063,7 @@
         "requestBody": {
           "required": true,
           "schema": {
-            "type": "JSON"
+            "type": "Post"
           }
         }
       },
@@ -1108,7 +1108,7 @@
         "requestBody": {
           "required": true,
           "schema": {
-            "type": "JSON"
+            "type": "Post"
           }
         }
       },
@@ -1189,10 +1189,6 @@
       "representation": {
         "type": "integer"
       }
-    },
-    "JSON": {
-      "aggregate_functions": {},
-      "comparison_operators": {}
     },
     "NotFoundError": {
       "aggregate_functions": {},

--- a/openapi/testdata/petstore2/expected.json
+++ b/openapi/testdata/petstore2/expected.json
@@ -659,7 +659,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "JSON",
+              "name": "Base64",
               "type": "named"
             }
           }
@@ -695,7 +695,7 @@
           "required": true,
           "contentType": "application/json",
           "schema": {
-            "type": "JSON"
+            "type": "Pet"
           }
         }
       },
@@ -734,7 +734,7 @@
           "required": true,
           "contentType": "application/json",
           "schema": {
-            "type": "JSON"
+            "type": "Pet"
           }
         }
       },
@@ -908,7 +908,7 @@
           "required": true,
           "contentType": "application/json",
           "schema": {
-            "type": "JSON"
+            "type": "Order"
           }
         }
       },
@@ -984,7 +984,7 @@
           "required": true,
           "contentType": "application/json",
           "schema": {
-            "type": "JSON"
+            "type": "User"
           }
         }
       },
@@ -1064,6 +1064,13 @@
     }
   ],
   "scalar_types": {
+    "Base64": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "string"
+      }
+    },
     "BigInt": {
       "aggregate_functions": {},
       "comparison_operators": {}

--- a/openapi/testdata/petstore2/expected.json
+++ b/openapi/testdata/petstore2/expected.json
@@ -37,12 +37,19 @@
           {
             "name": "status",
             "in": "query",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "array",
+              "nullable": false
+            }
           }
         ],
         "security": [
           {
-            "petstore_auth": ["write:pets", "read:pets"]
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
           }
         ]
       },
@@ -76,12 +83,19 @@
           {
             "name": "tags",
             "in": "query",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "array",
+              "nullable": false
+            }
           }
         ],
         "security": [
           {
-            "petstore_auth": ["write:pets", "read:pets"]
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
           }
         ]
       },
@@ -115,7 +129,12 @@
           {
             "name": "petId",
             "in": "path",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "nullable": false
+            }
           }
         ],
         "security": [
@@ -128,7 +147,7 @@
         "petId": {
           "description": "ID of pet to return",
           "type": {
-            "name": "Int",
+            "name": "BigInt",
             "type": "named"
           }
         }
@@ -148,7 +167,14 @@
           {
             "name": "orderId",
             "in": "path",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "nullable": false,
+              "maximum": 10,
+              "minimum": 1
+            }
           }
         ]
       },
@@ -156,7 +182,7 @@
         "orderId": {
           "description": "ID of pet that needs to be fetched",
           "type": {
-            "name": "Int",
+            "name": "BigInt",
             "type": "named"
           }
         }
@@ -194,7 +220,11 @@
           {
             "name": "username",
             "in": "path",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "string",
+              "nullable": false
+            }
           }
         ]
       },
@@ -222,12 +252,20 @@
           {
             "name": "username",
             "in": "query",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "string",
+              "nullable": false
+            }
           },
           {
             "name": "password",
             "in": "query",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "string",
+              "nullable": false
+            }
           }
         ]
       },
@@ -306,7 +344,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -337,7 +375,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -346,7 +384,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -364,7 +402,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "String",
+              "name": "DateTime",
               "type": "named"
             }
           }
@@ -396,7 +434,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -446,7 +484,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -468,7 +506,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -508,7 +546,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -565,26 +603,101 @@
   "procedures": [
     {
       "request": {
-        "url": "/pet",
+        "url": "/pet/{petId}/uploadImage",
         "method": "post",
-        "headers": {
-          "Content-Type": "application/json"
-        },
         "parameters": [
           {
-            "name": "body",
-            "in": "body",
+            "name": "petId",
+            "in": "path",
             "required": true,
             "schema": {
-              "type": "JSON"
+              "type": "integer",
+              "format": "int64",
+              "nullable": false
             }
           }
         ],
         "security": [
           {
-            "petstore_auth": ["write:pets", "read:pets"]
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
           }
-        ]
+        ],
+        "requestBody": {
+          "required": true,
+          "contentType": "multipart/form-data",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "additionalMetadata": {
+                "type": "string",
+                "nullable": true
+              },
+              "file": {
+                "type": "file",
+                "nullable": true
+              }
+            }
+          }
+        }
+      },
+      "arguments": {
+        "additionalMetadata": {
+          "description": "Additional data to pass to server",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "file": {
+          "description": "file to upload",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "JSON",
+              "type": "named"
+            }
+          }
+        },
+        "petId": {
+          "description": "ID of pet to update",
+          "type": {
+            "name": "BigInt",
+            "type": "named"
+          }
+        }
+      },
+      "description": "uploads an image",
+      "name": "uploadFile",
+      "result_type": {
+        "name": "ApiResponse",
+        "type": "named"
+      }
+    },
+    {
+      "request": {
+        "url": "/pet",
+        "method": "post",
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "contentType": "application/json",
+          "schema": {
+            "type": "JSON"
+          }
+        }
       },
       "arguments": {
         "body": {
@@ -609,24 +722,21 @@
       "request": {
         "url": "/pet",
         "method": "put",
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "type": "JSON"
-            }
-          }
-        ],
         "security": [
           {
-            "petstore_auth": ["write:pets", "read:pets"]
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
           }
-        ]
+        ],
+        "requestBody": {
+          "required": true,
+          "contentType": "application/json",
+          "schema": {
+            "type": "JSON"
+          }
+        }
       },
       "arguments": {
         "body": {
@@ -650,25 +760,115 @@
     {
       "request": {
         "url": "/pet/{petId}",
-        "method": "delete",
-        "headers": {
-          "Content-Type": "application/json"
-        },
+        "method": "post",
         "parameters": [
-          {
-            "name": "api_key",
-            "in": "header",
-            "required": false
-          },
           {
             "name": "petId",
             "in": "path",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "nullable": false
+            }
           }
         ],
         "security": [
           {
-            "petstore_auth": ["write:pets", "read:pets"]
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "contentType": "application/x-www-form-urlencoded",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "nullable": true
+              },
+              "status": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          }
+        }
+      },
+      "arguments": {
+        "name": {
+          "description": "Updated name of the pet",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "petId": {
+          "description": "ID of pet that needs to be updated",
+          "type": {
+            "name": "BigInt",
+            "type": "named"
+          }
+        },
+        "status": {
+          "description": "Updated status of the pet",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        }
+      },
+      "description": "Updates a pet in the store with form data",
+      "name": "updatePetWithForm",
+      "result_type": {
+        "type": "nullable",
+        "underlying_type": {
+          "name": "Boolean",
+          "type": "named"
+        }
+      }
+    },
+    {
+      "request": {
+        "url": "/pet/{petId}",
+        "method": "delete",
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "nullable": false
+            }
+          }
+        ],
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
           }
         ]
       },
@@ -685,7 +885,7 @@
         "petId": {
           "description": "Pet id to delete",
           "type": {
-            "name": "Int",
+            "name": "BigInt",
             "type": "named"
           }
         }
@@ -704,19 +904,13 @@
       "request": {
         "url": "/store/order",
         "method": "post",
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "type": "JSON"
-            }
+        "requestBody": {
+          "required": true,
+          "contentType": "application/json",
+          "schema": {
+            "type": "JSON"
           }
-        ]
+        }
       },
       "arguments": {
         "body": {
@@ -738,14 +932,17 @@
       "request": {
         "url": "/store/order/{orderId}",
         "method": "delete",
-        "headers": {
-          "Content-Type": "application/json"
-        },
         "parameters": [
           {
             "name": "orderId",
             "in": "path",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "nullable": false,
+              "minimum": 1
+            }
           }
         ]
       },
@@ -753,7 +950,7 @@
         "orderId": {
           "description": "ID of the order that needs to be deleted",
           "type": {
-            "name": "Int",
+            "name": "BigInt",
             "type": "named"
           }
         }
@@ -772,24 +969,24 @@
       "request": {
         "url": "/user/{username}",
         "method": "put",
-        "headers": {
-          "Content-Type": "application/json"
-        },
         "parameters": [
           {
             "name": "username",
             "in": "path",
-            "required": true
-          },
-          {
-            "name": "body",
-            "in": "body",
             "required": true,
             "schema": {
-              "type": "JSON"
+              "type": "string",
+              "nullable": false
             }
           }
-        ]
+        ],
+        "requestBody": {
+          "required": true,
+          "contentType": "application/json",
+          "schema": {
+            "type": "JSON"
+          }
+        }
       },
       "arguments": {
         "body": {
@@ -821,14 +1018,15 @@
       "request": {
         "url": "/user/{username}",
         "method": "delete",
-        "headers": {
-          "Content-Type": "application/json"
-        },
         "parameters": [
           {
             "name": "username",
             "in": "path",
-            "required": true
+            "required": true,
+            "schema": {
+              "type": "string",
+              "nullable": false
+            }
           }
         ]
       },
@@ -854,10 +1052,7 @@
     {
       "request": {
         "url": "/snake",
-        "method": "post",
-        "headers": {
-          "Content-Type": "application/json"
-        }
+        "method": "post"
       },
       "arguments": {},
       "description": "Create snake",
@@ -869,11 +1064,22 @@
     }
   ],
   "scalar_types": {
+    "BigInt": {
+      "aggregate_functions": {},
+      "comparison_operators": {}
+    },
     "Boolean": {
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
         "type": "boolean"
+      }
+    },
+    "DateTime": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "string"
       }
     },
     "Int": {
@@ -891,7 +1097,11 @@
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
-        "one_of": ["placed", "approved", "delivered"],
+        "one_of": [
+          "placed",
+          "approved",
+          "delivered"
+        ],
         "type": "enum"
       }
     },
@@ -899,7 +1109,11 @@
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
-        "one_of": ["available", "pending", "sold"],
+        "one_of": [
+          "available",
+          "pending",
+          "sold"
+        ],
         "type": "enum"
       }
     },

--- a/openapi/testdata/petstore3/expected.json
+++ b/openapi/testdata/petstore3/expected.json
@@ -31,7 +31,10 @@
     "security": [
       {},
       {
-        "petstore_auth": ["write:pets", "read:pets"]
+        "petstore_auth": [
+          "write:pets",
+          "read:pets"
+        ]
       }
     ],
     "version": "1.0.19"
@@ -49,13 +52,20 @@
             "required": false,
             "schema": {
               "type": "PetStatus",
-              "enum": ["available", "pending", "sold"]
+              "enum": [
+                "available",
+                "pending",
+                "sold"
+              ]
             }
           }
         ],
         "security": [
           {
-            "petstore_auth": ["write:pets", "read:pets"]
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
           }
         ]
       },
@@ -97,7 +107,10 @@
         ],
         "security": [
           {
-            "petstore_auth": ["write:pets", "read:pets"]
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
           }
         ]
       },
@@ -136,7 +149,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "Int",
+              "type": "BigInt",
               "format": "int64"
             }
           }
@@ -146,7 +159,10 @@
             "api_key": []
           },
           {
-            "petstore_auth": ["write:pets", "read:pets"]
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
           }
         ]
       },
@@ -154,7 +170,7 @@
         "petId": {
           "description": "ID of pet to return",
           "type": {
-            "name": "Int",
+            "name": "BigInt",
             "type": "named"
           }
         }
@@ -194,7 +210,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "Int",
+              "type": "BigInt",
               "format": "int64"
             }
           }
@@ -204,7 +220,7 @@
         "orderId": {
           "description": "ID of order that needs to be fetched",
           "type": {
-            "name": "Int",
+            "name": "BigInt",
             "type": "named"
           }
         }
@@ -391,7 +407,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -425,7 +441,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -437,6 +453,17 @@
               "name": "String",
               "type": "named"
             }
+          }
+        }
+      }
+    },
+    "Error": {
+      "description": "An error response from the Stripe API",
+      "fields": {
+        "error": {
+          "type": {
+            "name": "String",
+            "type": "named"
           }
         }
       }
@@ -456,7 +483,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -465,7 +492,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -483,7 +510,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "String",
+              "name": "DateTime",
               "type": "named"
             }
           }
@@ -515,7 +542,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -587,7 +614,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -596,7 +623,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -614,7 +641,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "String",
+              "name": "DateTime",
               "type": "named"
             }
           }
@@ -637,7 +664,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -648,6 +675,214 @@
             "underlying_type": {
               "name": "String",
               "type": "named"
+            }
+          }
+        }
+      }
+    },
+    "TreasuryInboundTransfer": {
+      "description": "Use [InboundTransfers](https://stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers) to add funds to your [FinancialAccount](https://stripe.com/docs/api#financial_accounts) via a PaymentMethod that is owned by you. The funds will be transferred via an ACH debit.",
+      "fields": {
+        "amount": {
+          "description": "Amount (in cents) transferred.",
+          "type": {
+            "name": "Int",
+            "type": "named"
+          }
+        },
+        "cancelable": {
+          "description": "Returns `true` if the InboundTransfer is able to be canceled.",
+          "type": {
+            "name": "Boolean",
+            "type": "named"
+          }
+        },
+        "created": {
+          "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
+          "type": {
+            "name": "UnixTime",
+            "type": "named"
+          }
+        },
+        "currency": {
+          "description": "Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).",
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "description": {
+          "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "nullable",
+              "underlying_type": {
+                "name": "String",
+                "type": "named"
+              }
+            }
+          }
+        },
+        "failure_details": {
+          "description": "Details about this InboundTransfer's failure. Only set when status is `failed`.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "JSON",
+              "type": "named"
+            }
+          }
+        },
+        "financial_account": {
+          "description": "The FinancialAccount that received the funds.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "hosted_regulatory_receipt_url": {
+          "description": "A [hosted transaction receipt](https://stripe.com/docs/treasury/moving-money/regulatory-receipts) URL that is provided when money movement is considered regulated under Stripe's money transmission licenses.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "nullable",
+              "underlying_type": {
+                "name": "String",
+                "type": "named"
+              }
+            }
+          }
+        },
+        "id": {
+          "description": "Unique identifier for the object.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "livemode": {
+          "description": "Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.",
+          "type": {
+            "name": "Boolean",
+            "type": "named"
+          }
+        },
+        "metadata": {
+          "description": "Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.",
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          }
+        },
+        "object": {
+          "description": "String representing the object's type. Objects of the same type share the same value.",
+          "type": {
+            "name": "TreasuryInboundTransferObject",
+            "type": "named"
+          }
+        },
+        "origin_payment_method": {
+          "description": "The origin payment method to be debited for an InboundTransfer.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "returned": {
+          "description": "Returns `true` if the funds for an InboundTransfer were returned after the InboundTransfer went to the `succeeded` state.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "nullable",
+              "underlying_type": {
+                "name": "Boolean",
+                "type": "named"
+              }
+            }
+          }
+        },
+        "statement_descriptor": {
+          "description": "Statement descriptor shown when funds are debited from the source. Not all payment networks support `statement_descriptor`.",
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "status": {
+          "description": "Status of the InboundTransfer: `processing`, `succeeded`, `failed`, and `canceled`. An InboundTransfer is `processing` if it is created and pending. The status changes to `succeeded` once the funds have been \"confirmed\" and a `transaction` is created and posted. The status changes to `failed` if the transfer fails.",
+          "type": {
+            "name": "TreasuryInboundTransferStatus",
+            "type": "named"
+          }
+        },
+        "status_transitions": {
+          "type": {
+            "name": "TreasuryInboundTransfersResourceInboundTransferResourceStatusTransitions",
+            "type": "named"
+          }
+        },
+        "transaction": {
+          "description": "The Transaction associated with this object.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "JSON",
+              "type": "named"
+            }
+          }
+        }
+      }
+    },
+    "TreasuryInboundTransfersResourceFailureDetails": {
+      "fields": {
+        "code": {
+          "description": "Reason for the failure.",
+          "type": {
+            "name": "TreasuryInboundTransfersResourceFailureDetailsCode",
+            "type": "named"
+          }
+        }
+      }
+    },
+    "TreasuryInboundTransfersResourceInboundTransferResourceStatusTransitions": {
+      "fields": {
+        "canceled_at": {
+          "description": "Timestamp describing when an InboundTransfer changed status to `canceled`.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "nullable",
+              "underlying_type": {
+                "name": "UnixTime",
+                "type": "named"
+              }
+            }
+          }
+        },
+        "failed_at": {
+          "description": "Timestamp describing when an InboundTransfer changed status to `failed`.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "nullable",
+              "underlying_type": {
+                "name": "UnixTime",
+                "type": "named"
+              }
+            }
+          }
+        },
+        "succeeded_at": {
+          "description": "Timestamp describing when an InboundTransfer changed status to `succeeded`.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "type": "nullable",
+              "underlying_type": {
+                "name": "UnixTime",
+                "type": "named"
+              }
             }
           }
         }
@@ -677,7 +912,7 @@
           "type": {
             "type": "nullable",
             "underlying_type": {
-              "name": "Int",
+              "name": "BigInt",
               "type": "named"
             }
           }
@@ -736,14 +971,21 @@
       "request": {
         "url": "/pet",
         "method": "post",
-        "headers": {
-          "Content-Type": "application/json"
-        },
         "security": [
           {
-            "petstore_auth": ["write:pets", "read:pets"]
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
           }
-        ]
+        ],
+        "requestBody": {
+          "required": true,
+          "contentType": "application/json",
+          "schema": {
+            "type": "Pet"
+          }
+        }
       },
       "arguments": {
         "body": {
@@ -765,14 +1007,21 @@
       "request": {
         "url": "/pet",
         "method": "put",
-        "headers": {
-          "Content-Type": "application/json"
-        },
         "security": [
           {
-            "petstore_auth": ["write:pets", "read:pets"]
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
           }
-        ]
+        ],
+        "requestBody": {
+          "required": true,
+          "contentType": "application/json",
+          "schema": {
+            "type": "Pet"
+          }
+        }
       },
       "arguments": {
         "body": {
@@ -794,16 +1043,13 @@
       "request": {
         "url": "/pet/{petId}",
         "method": "post",
-        "headers": {
-          "Content-Type": ""
-        },
         "parameters": [
           {
             "name": "petId",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "Int",
+              "type": "BigInt",
               "format": "int64"
             }
           },
@@ -826,7 +1072,10 @@
         ],
         "security": [
           {
-            "petstore_auth": ["write:pets", "read:pets"]
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
           }
         ]
       },
@@ -844,7 +1093,7 @@
         "petId": {
           "description": "ID of pet that needs to be updated",
           "type": {
-            "name": "Int",
+            "name": "BigInt",
             "type": "named"
           }
         },
@@ -873,9 +1122,6 @@
       "request": {
         "url": "/pet/{petId}",
         "method": "delete",
-        "headers": {
-          "Content-Type": ""
-        },
         "parameters": [
           {
             "name": "api_key",
@@ -890,14 +1136,17 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "Int",
+              "type": "BigInt",
               "format": "int64"
             }
           }
         ],
         "security": [
           {
-            "petstore_auth": ["write:pets", "read:pets"]
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
           }
         ]
       },
@@ -914,7 +1163,7 @@
         "petId": {
           "description": "Pet id to delete",
           "type": {
-            "name": "Int",
+            "name": "BigInt",
             "type": "named"
           }
         }
@@ -933,16 +1182,13 @@
       "request": {
         "url": "/pet/{petId}/uploadImage",
         "method": "post",
-        "headers": {
-          "Content-Type": "application/octet-stream"
-        },
         "parameters": [
           {
             "name": "petId",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "Int",
+              "type": "BigInt",
               "format": "int64"
             }
           },
@@ -957,9 +1203,19 @@
         ],
         "security": [
           {
-            "petstore_auth": ["write:pets", "read:pets"]
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
           }
-        ]
+        ],
+        "requestBody": {
+          "contentType": "application/octet-stream",
+          "schema": {
+            "type": "Base64",
+            "format": "binary"
+          }
+        }
       },
       "arguments": {
         "additionalMetadata": {
@@ -972,10 +1228,17 @@
             }
           }
         },
+        "body": {
+          "description": "Request body of /pet/{petId}/uploadImage",
+          "type": {
+            "name": "Base64",
+            "type": "named"
+          }
+        },
         "petId": {
           "description": "ID of pet to update",
           "type": {
-            "name": "Int",
+            "name": "BigInt",
             "type": "named"
           }
         }
@@ -991,8 +1254,11 @@
       "request": {
         "url": "/store/order",
         "method": "post",
-        "headers": {
-          "Content-Type": "application/json"
+        "requestBody": {
+          "contentType": "application/json",
+          "schema": {
+            "type": "Order"
+          }
         }
       },
       "arguments": {
@@ -1015,16 +1281,13 @@
       "request": {
         "url": "/store/order/{orderId}",
         "method": "delete",
-        "headers": {
-          "Content-Type": ""
-        },
         "parameters": [
           {
             "name": "orderId",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "Int",
+              "type": "BigInt",
               "format": "int64"
             }
           }
@@ -1034,7 +1297,7 @@
         "orderId": {
           "description": "ID of the order that needs to be deleted",
           "type": {
-            "name": "Int",
+            "name": "BigInt",
             "type": "named"
           }
         }
@@ -1053,8 +1316,11 @@
       "request": {
         "url": "/user/createWithList",
         "method": "post",
-        "headers": {
-          "Content-Type": "application/json"
+        "requestBody": {
+          "contentType": "application/json",
+          "schema": {
+            "type": "array"
+          }
         }
       },
       "arguments": {
@@ -1080,9 +1346,6 @@
       "request": {
         "url": "/user/{username}",
         "method": "delete",
-        "headers": {
-          "Content-Type": ""
-        },
         "parameters": [
           {
             "name": "username",
@@ -1116,10 +1379,7 @@
     {
       "request": {
         "url": "/snake",
-        "method": "post",
-        "headers": {
-          "Content-Type": ""
-        }
+        "method": "post"
       },
       "arguments": {},
       "description": "Add snake object",
@@ -1128,14 +1388,75 @@
         "name": "SnakeObject",
         "type": "named"
       }
+    },
+    {
+      "request": {
+        "url": "/test_helpers/treasury/inbound_transfers/{id}/fail",
+        "method": "post",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "String",
+              "maxLength": 5000
+            }
+          }
+        ],
+        "requestBody": {
+          "contentType": "application/x-www-form-urlencoded",
+          "schema": {
+            "type": "JSON"
+          }
+        }
+      },
+      "arguments": {
+        "body": {
+          "description": "Request body of /test_helpers/treasury/inbound_transfers/{id}/fail",
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          }
+        },
+        "id": {
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        }
+      },
+      "name": "PostTestHelpersTreasuryInboundTransfersIdFail",
+      "result_type": {
+        "name": "TreasuryInboundTransfer",
+        "type": "named"
+      }
     }
   ],
   "scalar_types": {
+    "Base64": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "string"
+      }
+    },
+    "BigInt": {
+      "aggregate_functions": {},
+      "comparison_operators": {}
+    },
     "Boolean": {
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
         "type": "boolean"
+      }
+    },
+    "DateTime": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "string"
       }
     },
     "Int": {
@@ -1153,7 +1474,11 @@
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
-        "one_of": ["placed", "approved", "delivered"],
+        "one_of": [
+          "placed",
+          "approved",
+          "delivered"
+        ],
         "type": "enum"
       }
     },
@@ -1161,7 +1486,11 @@
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
-        "one_of": ["available", "pending", "sold"],
+        "one_of": [
+          "available",
+          "pending",
+          "sold"
+        ],
         "type": "enum"
       }
     },
@@ -1169,7 +1498,11 @@
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
-        "one_of": ["placed", "approved", "delivered"],
+        "one_of": [
+          "placed",
+          "approved",
+          "delivered"
+        ],
         "type": "enum"
       }
     },
@@ -1178,6 +1511,58 @@
       "comparison_operators": {},
       "representation": {
         "type": "string"
+      }
+    },
+    "TreasuryInboundTransferObject": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "treasury.inbound_transfer"
+        ],
+        "type": "enum"
+      }
+    },
+    "TreasuryInboundTransferStatus": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "canceled",
+          "failed",
+          "processing",
+          "succeeded"
+        ],
+        "type": "enum"
+      }
+    },
+    "TreasuryInboundTransfersResourceFailureDetailsCode": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "account_closed",
+          "account_frozen",
+          "bank_account_restricted",
+          "bank_ownership_changed",
+          "debit_not_authorized",
+          "incorrect_account_holder_address",
+          "incorrect_account_holder_name",
+          "incorrect_account_holder_tax_id",
+          "insufficient_funds",
+          "invalid_account_number",
+          "invalid_currency",
+          "no_account",
+          "other"
+        ],
+        "type": "enum"
+      }
+    },
+    "UnixTime": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "integer"
       }
     }
   }

--- a/openapi/testdata/petstore3/expected.json
+++ b/openapi/testdata/petstore3/expected.json
@@ -51,7 +51,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "PetStatus",
+              "type": "string",
               "enum": [
                 "available",
                 "pending",
@@ -101,7 +101,10 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "JSON"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -149,7 +152,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "BigInt",
+              "type": "integer",
               "format": "int64"
             }
           }
@@ -210,7 +213,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "BigInt",
+              "type": "integer",
               "format": "int64"
             }
           }
@@ -242,7 +245,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "String"
+              "type": "string"
             }
           },
           {
@@ -250,7 +253,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "String"
+              "type": "string"
             }
           }
         ]
@@ -294,7 +297,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "string"
             }
           }
         ]
@@ -468,6 +471,20 @@
         }
       }
     },
+    "FailureDetailsParams": {
+      "description": "Details about a failed InboundTransfer.",
+      "fields": {
+        "code": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "TestHelpersCode",
+              "type": "named"
+            }
+          }
+        }
+      }
+    },
     "Order": {
       "fields": {
         "complete": {
@@ -581,6 +598,33 @@
                 "type": "named"
               },
               "type": "array"
+            }
+          }
+        }
+      }
+    },
+    "PostTestHelpersTreasuryInboundTransfersIdFail": {
+      "fields": {
+        "expand": {
+          "description": "Specifies which fields in the response should be expanded.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "String",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "failure_details": {
+          "description": "Details about a failed InboundTransfer.",
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "FailureDetailsParams",
+              "type": "named"
             }
           }
         }
@@ -1049,7 +1093,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "BigInt",
+              "type": "integer",
               "format": "int64"
             }
           },
@@ -1058,7 +1102,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "String"
+              "type": "string"
             }
           },
           {
@@ -1066,7 +1110,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "String"
+              "type": "string"
             }
           }
         ],
@@ -1128,7 +1172,7 @@
             "in": "header",
             "required": false,
             "schema": {
-              "type": "String"
+              "type": "string"
             }
           },
           {
@@ -1136,7 +1180,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "BigInt",
+              "type": "integer",
               "format": "int64"
             }
           }
@@ -1188,7 +1232,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "BigInt",
+              "type": "integer",
               "format": "int64"
             }
           },
@@ -1197,7 +1241,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "String"
+              "type": "string"
             }
           }
         ],
@@ -1212,7 +1256,7 @@
         "requestBody": {
           "contentType": "application/octet-stream",
           "schema": {
-            "type": "Base64",
+            "type": "string",
             "format": "binary"
           }
         }
@@ -1287,7 +1331,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "BigInt",
+              "type": "integer",
               "format": "int64"
             }
           }
@@ -1352,7 +1396,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "String"
+              "type": "string"
             }
           }
         ]
@@ -1399,7 +1443,7 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "String",
+              "type": "string",
               "maxLength": 5000
             }
           }
@@ -1407,7 +1451,49 @@
         "requestBody": {
           "contentType": "application/x-www-form-urlencoded",
           "schema": {
-            "type": "JSON"
+            "type": "object",
+            "properties": {
+              "expand": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "maxLength": 5000
+                }
+              },
+              "failure_details": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "enum": [
+                      "account_closed",
+                      "account_frozen",
+                      "bank_account_restricted",
+                      "bank_ownership_changed",
+                      "debit_not_authorized",
+                      "incorrect_account_holder_address",
+                      "incorrect_account_holder_name",
+                      "incorrect_account_holder_tax_id",
+                      "insufficient_funds",
+                      "invalid_account_number",
+                      "invalid_currency",
+                      "no_account",
+                      "other"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "encoding": {
+            "expand": {
+              "style": "deepObject",
+              "explode": true
+            },
+            "failure_details": {
+              "style": "deepObject",
+              "explode": true
+            }
           }
         }
       },
@@ -1415,7 +1501,7 @@
         "body": {
           "description": "Request body of /test_helpers/treasury/inbound_transfers/{id}/fail",
           "type": {
-            "name": "JSON",
+            "name": "PostTestHelpersTreasuryInboundTransfersIdFail",
             "type": "named"
           }
         },
@@ -1511,6 +1597,28 @@
       "comparison_operators": {},
       "representation": {
         "type": "string"
+      }
+    },
+    "TestHelpersCode": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "one_of": [
+          "account_closed",
+          "account_frozen",
+          "bank_account_restricted",
+          "bank_ownership_changed",
+          "debit_not_authorized",
+          "incorrect_account_holder_address",
+          "incorrect_account_holder_name",
+          "incorrect_account_holder_tax_id",
+          "insufficient_funds",
+          "invalid_account_number",
+          "invalid_currency",
+          "no_account",
+          "other"
+        ],
+        "type": "enum"
       }
     },
     "TreasuryInboundTransferObject": {

--- a/openapi/testdata/petstore3/source.json
+++ b/openapi/testdata/petstore3/source.json
@@ -902,6 +902,102 @@
           }
         }
       }
+    },
+    "/test_helpers/treasury/inbound_transfers/{id}/fail": {
+      "post": {
+        "description": "<p>Transitions a test mode created InboundTransfer to the <code>failed</code> status. The InboundTransfer must already be in the <code>processing</code> state.</p>",
+        "operationId": "PostTestHelpersTreasuryInboundTransfersIdFail",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "maxLength": 5000,
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "encoding": {
+                "expand": {
+                  "explode": true,
+                  "style": "deepObject"
+                },
+                "failure_details": {
+                  "explode": true,
+                  "style": "deepObject"
+                }
+              },
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "expand": {
+                    "description": "Specifies which fields in the response should be expanded.",
+                    "items": {
+                      "maxLength": 5000,
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "failure_details": {
+                    "description": "Details about a failed InboundTransfer.",
+                    "properties": {
+                      "code": {
+                        "enum": [
+                          "account_closed",
+                          "account_frozen",
+                          "bank_account_restricted",
+                          "bank_ownership_changed",
+                          "debit_not_authorized",
+                          "incorrect_account_holder_address",
+                          "incorrect_account_holder_name",
+                          "incorrect_account_holder_tax_id",
+                          "insufficient_funds",
+                          "invalid_account_number",
+                          "invalid_currency",
+                          "no_account",
+                          "other"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "title": "failure_details_params",
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/treasury.inbound_transfer"
+                }
+              }
+            },
+            "description": "Successful response."
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            },
+            "description": "Error response."
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1163,6 +1259,202 @@
             "xml": { "name": "order" }
           }
         }
+      },
+      "treasury.inbound_transfer": {
+        "description": "Use [InboundTransfers](https://stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers) to add funds to your [FinancialAccount](https://stripe.com/docs/api#financial_accounts) via a PaymentMethod that is owned by you. The funds will be transferred via an ACH debit.",
+        "properties": {
+          "amount": {
+            "description": "Amount (in cents) transferred.",
+            "type": "integer"
+          },
+          "cancelable": {
+            "description": "Returns `true` if the InboundTransfer is able to be canceled.",
+            "type": "boolean"
+          },
+          "created": {
+            "description": "Time at which the object was created. Measured in seconds since the Unix epoch.",
+            "format": "unix-time",
+            "type": "integer"
+          },
+          "currency": {
+            "description": "Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).",
+            "type": "string"
+          },
+          "description": {
+            "description": "An arbitrary string attached to the object. Often useful for displaying to users.",
+            "maxLength": 5000,
+            "nullable": true,
+            "type": "string"
+          },
+          "failure_details": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/treasury_inbound_transfers_resource_failure_details"
+              }
+            ],
+            "description": "Details about this InboundTransfer's failure. Only set when status is `failed`.",
+            "nullable": true
+          },
+          "financial_account": {
+            "description": "The FinancialAccount that received the funds.",
+            "maxLength": 5000,
+            "type": "string"
+          },
+          "hosted_regulatory_receipt_url": {
+            "description": "A [hosted transaction receipt](https://stripe.com/docs/treasury/moving-money/regulatory-receipts) URL that is provided when money movement is considered regulated under Stripe's money transmission licenses.",
+            "maxLength": 5000,
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the object.",
+            "maxLength": 5000,
+            "type": "string"
+          },
+          "livemode": {
+            "description": "Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.",
+            "type": "boolean"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "maxLength": 500,
+              "type": "string"
+            },
+            "description": "Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.",
+            "type": "object"
+          },
+          "object": {
+            "description": "String representing the object's type. Objects of the same type share the same value.",
+            "enum": ["treasury.inbound_transfer"],
+            "type": "string"
+          },
+          "origin_payment_method": {
+            "description": "The origin payment method to be debited for an InboundTransfer.",
+            "maxLength": 5000,
+            "type": "string"
+          },
+          "returned": {
+            "description": "Returns `true` if the funds for an InboundTransfer were returned after the InboundTransfer went to the `succeeded` state.",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "statement_descriptor": {
+            "description": "Statement descriptor shown when funds are debited from the source. Not all payment networks support `statement_descriptor`.",
+            "maxLength": 5000,
+            "type": "string"
+          },
+          "status": {
+            "description": "Status of the InboundTransfer: `processing`, `succeeded`, `failed`, and `canceled`. An InboundTransfer is `processing` if it is created and pending. The status changes to `succeeded` once the funds have been \"confirmed\" and a `transaction` is created and posted. The status changes to `failed` if the transfer fails.",
+            "enum": ["canceled", "failed", "processing", "succeeded"],
+            "type": "string"
+          },
+          "status_transitions": {
+            "$ref": "#/components/schemas/treasury_inbound_transfers_resource_inbound_transfer_resource_status_transitions"
+          },
+          "transaction": {
+            "anyOf": [
+              {
+                "maxLength": 5000,
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "description": "The Transaction associated with this object.",
+            "nullable": true
+          }
+        },
+        "required": [
+          "amount",
+          "cancelable",
+          "created",
+          "currency",
+          "financial_account",
+          "id",
+          "linked_flows",
+          "livemode",
+          "metadata",
+          "object",
+          "origin_payment_method",
+          "statement_descriptor",
+          "status",
+          "status_transitions"
+        ],
+        "title": "TreasuryInboundTransfersResourceInboundTransfer",
+        "type": "object",
+        "x-expandableFields": [
+          "failure_details",
+          "linked_flows",
+          "origin_payment_method_details",
+          "status_transitions",
+          "transaction"
+        ],
+        "x-resourceId": "treasury.inbound_transfer"
+      },
+      "treasury_inbound_transfers_resource_inbound_transfer_resource_status_transitions": {
+        "description": "",
+        "properties": {
+          "canceled_at": {
+            "description": "Timestamp describing when an InboundTransfer changed status to `canceled`.",
+            "format": "unix-time",
+            "nullable": true,
+            "type": "integer"
+          },
+          "failed_at": {
+            "description": "Timestamp describing when an InboundTransfer changed status to `failed`.",
+            "format": "unix-time",
+            "nullable": true,
+            "type": "integer"
+          },
+          "succeeded_at": {
+            "description": "Timestamp describing when an InboundTransfer changed status to `succeeded`.",
+            "format": "unix-time",
+            "nullable": true,
+            "type": "integer"
+          }
+        },
+        "title": "TreasuryInboundTransfersResourceInboundTransferResourceStatusTransitions",
+        "type": "object",
+        "x-expandableFields": []
+      },
+      "treasury_inbound_transfers_resource_failure_details": {
+        "description": "",
+        "properties": {
+          "code": {
+            "description": "Reason for the failure.",
+            "enum": [
+              "account_closed",
+              "account_frozen",
+              "bank_account_restricted",
+              "bank_ownership_changed",
+              "debit_not_authorized",
+              "incorrect_account_holder_address",
+              "incorrect_account_holder_name",
+              "incorrect_account_holder_tax_id",
+              "insufficient_funds",
+              "invalid_account_number",
+              "invalid_currency",
+              "no_account",
+              "other"
+            ],
+            "type": "string"
+          }
+        },
+        "required": ["code"],
+        "title": "TreasuryInboundTransfersResourceFailureDetails",
+        "type": "object",
+        "x-expandableFields": []
+      },
+      "error": {
+        "description": "An error response from the Stripe API",
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": ["error"],
+        "type": "object"
       }
     },
     "requestBodies": {

--- a/openapi/v2.go
+++ b/openapi/v2.go
@@ -176,17 +176,18 @@ func (oc *openAPIv2Converter) pathToNDCOperations(pathItem orderedmap.Pair[strin
 			return fmt.Errorf("%s: %s", pathKey, err)
 		}
 		if resultType != nil {
-			arguments, reqParams, err := oc.convertParameters(itemGet.Parameters, pathKey, []string{funcName})
+			arguments, reqParams, reqBody, err := oc.convertParameters(itemGet.Parameters, pathKey, []string{funcName})
 			if err != nil {
 				return fmt.Errorf("%s: %s", funcName, err)
 			}
 
 			function := rest.RESTFunctionInfo{
 				Request: &rest.Request{
-					URL:        pathKey,
-					Method:     "get",
-					Parameters: reqParams,
-					Security:   convertSecurities(itemGet.Security),
+					URL:         pathKey,
+					Method:      "get",
+					Parameters:  reqParams,
+					RequestBody: reqBody,
+					Security:    convertSecurities(itemGet.Security),
 				},
 				FunctionInfo: schema.FunctionInfo{
 					Name:       funcName,
@@ -257,25 +258,26 @@ func (oc *openAPIv2Converter) convertProcedureOperation(pathKey string, method s
 		return nil, nil
 	}
 
-	if len(operation.Consumes) > 0 && !slices.Contains(operation.Consumes, ContentTypeJSON) {
-		oc.Logger.Warn(fmt.Sprintf("Unsupported content types: %v", operation.Consumes))
-		return nil, nil
-	}
-
-	arguments, reqParams, err := oc.convertParameters(operation.Parameters, pathKey, []string{procName})
+	arguments, reqParams, reqBody, err := oc.convertParameters(operation.Parameters, pathKey, []string{procName})
 	if err != nil {
 		return nil, fmt.Errorf("%s: %s", pathKey, err)
 	}
 
+	if reqBody != nil && len(operation.Consumes) > 0 {
+		contentType := rest.ContentTypeJSON
+		if !slices.Contains(operation.Consumes, rest.ContentTypeJSON) {
+			contentType = operation.Consumes[0]
+		}
+		reqBody.ContentType = contentType
+	}
+
 	procedure := rest.RESTProcedureInfo{
 		Request: &rest.Request{
-			URL:        pathKey,
-			Method:     method,
-			Parameters: reqParams,
-			Security:   convertSecurities(operation.Security),
-			Headers: map[string]string{
-				ContentTypeHeader: ContentTypeJSON,
-			},
+			URL:         pathKey,
+			Method:      method,
+			Parameters:  reqParams,
+			RequestBody: reqBody,
+			Security:    convertSecurities(operation.Security),
 		},
 		ProcedureInfo: schema.ProcedureInfo{
 			Name:       procName,
@@ -291,26 +293,32 @@ func (oc *openAPIv2Converter) convertProcedureOperation(pathKey string, method s
 	return &procedure, nil
 }
 
-func (oc *openAPIv2Converter) convertParameters(params []*v2.Parameter, apiPath string, fieldPaths []string) (map[string]schema.ArgumentInfo, []rest.RequestParameter, error) {
+func (oc *openAPIv2Converter) convertParameters(params []*v2.Parameter, apiPath string, fieldPaths []string) (map[string]schema.ArgumentInfo, []rest.RequestParameter, *rest.RequestBody, error) {
 
 	if len(params) == 0 {
-		return map[string]schema.ArgumentInfo{}, nil, nil
+		return map[string]schema.ArgumentInfo{}, nil, nil, nil
 	}
 
 	var reqParams []rest.RequestParameter
 	arguments := make(map[string]schema.ArgumentInfo)
 
+	var requestBody *rest.RequestBody
+	formData := rest.TypeSchema{
+		Type:       "object",
+		Properties: make(map[string]rest.TypeSchema),
+	}
 	for _, param := range params {
 		if param == nil {
 			continue
 		}
 		paramName := param.Name
 		if paramName == "" {
-			return nil, nil, errors.New("parameter name is empty")
+			return nil, nil, nil, errors.New("parameter name is empty")
 		}
 
 		var schemaType schema.TypeEncoder
 		var apiSchema *base.Schema
+		var typeSchema *rest.TypeSchema
 		var err error
 
 		paramRequired := false
@@ -318,30 +326,51 @@ func (oc *openAPIv2Converter) convertParameters(params []*v2.Parameter, apiPath 
 			paramRequired = true
 		}
 
-		if param.Schema != nil {
-			schemaType, apiSchema, err = oc.getSchemaTypeFromProxy(param.Schema, !paramRequired, apiPath, fieldPaths)
-		} else {
+		var scalarName string
+		if param.Type != "" {
 			schemaType, err = oc.getSchemaTypeFromParameter(param, apiPath, fieldPaths)
-		}
-		if err != nil {
-			return nil, nil, err
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			nullable := !paramRequired
+			typeSchema = &rest.TypeSchema{
+				Type:     param.Type,
+				Format:   param.Format,
+				Pattern:  param.Pattern,
+				Nullable: &nullable,
+			}
+			if param.Maximum != nil {
+				maximum := float64(*param.Maximum)
+				typeSchema.Maximum = &maximum
+			}
+			if param.Minimum != nil {
+				minimum := float64(*param.Minimum)
+				typeSchema.Minimum = &minimum
+			}
+			if param.MaxLength != nil {
+				maxLength := int64(*param.MaxLength)
+				typeSchema.MaxLength = &maxLength
+			}
+			if param.MinLength != nil {
+				minLength := int64(*param.MinLength)
+				typeSchema.MinLength = &minLength
+			}
+		} else if param.Schema != nil {
+			schemaType, apiSchema, err = oc.getSchemaTypeFromProxy(param.Schema, !paramRequired, apiPath, fieldPaths)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			if apiSchema != nil && len(apiSchema.Type) > 0 {
+				scalarName = getScalarFromType(oc.schema, apiSchema.Type, apiSchema.Format, apiSchema.Enum, oc.trimPathPrefix(apiPath), fieldPaths)
+				typeSchema = ParseTypeSchemaFromOpenAPISchema(apiSchema, scalarName)
+			}
+
 		}
 
 		paramLocation, err := rest.ParseParameterLocation(param.In)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		var scalarName string
-		if apiSchema != nil && len(apiSchema.Type) > 0 {
-			scalarName = getScalarFromType(oc.schema, apiSchema.Type[0], apiSchema.Enum, oc.trimPathPrefix(apiPath), fieldPaths)
-		}
-
-		reqParams = append(reqParams, rest.RequestParameter{
-			Name:     paramName,
-			In:       paramLocation,
-			Required: paramRequired,
-			Schema:   ParseTypeSchemaFromOpenAPISchema(apiSchema, scalarName),
-		})
 
 		argument := schema.ArgumentInfo{
 			Type: schemaType.Encode(),
@@ -353,12 +382,35 @@ func (oc *openAPIv2Converter) convertParameters(params []*v2.Parameter, apiPath 
 		switch paramLocation {
 		case rest.InBody:
 			arguments["body"] = argument
+			requestBody = &rest.RequestBody{
+				Required: paramRequired,
+				Schema:   typeSchema,
+			}
+		case rest.InFormData:
+			arguments[paramName] = argument
+			if typeSchema != nil {
+				formData.Properties[paramName] = *typeSchema
+			}
 		default:
 			arguments[paramName] = argument
+			reqParams = append(reqParams, rest.RequestParameter{
+				Name:     paramName,
+				In:       paramLocation,
+				Required: paramRequired,
+				Schema:   typeSchema,
+			})
 		}
 	}
 
-	return arguments, reqParams, nil
+	if len(formData.Properties) > 0 {
+		requestBody = &rest.RequestBody{
+			Required:    true,
+			ContentType: rest.ContentTypeMultipartFormData,
+			Schema:      &formData,
+		}
+	}
+
+	return arguments, reqParams, requestBody, nil
 
 }
 
@@ -401,23 +453,24 @@ func (oc *openAPIv2Converter) getSchemaTypeFromParameter(param *v2.Parameter, ap
 	}
 
 	var result schema.TypeEncoder
-	switch param.Type {
-	case "boolean", "integer", "number", "string":
-		scalarName := getScalarFromType(oc.schema, param.Type, param.Enum, oc.trimPathPrefix(apiPath), fieldPaths)
+	if isPrimitiveScalar(param.Type) {
+		scalarName := getScalarFromType(oc.schema, []string{param.Type}, param.Format, param.Enum, oc.trimPathPrefix(apiPath), fieldPaths)
 		result = schema.NewNamedType(scalarName)
-	// case "null":
-	case "object":
-		return nil, errors.New("unsupported object parameter")
-	case "array":
-		if param.Items == nil && param.Items.Type == "" {
-			return nil, errors.New("array item is empty")
+	} else {
+		switch param.Type {
+		case "object":
+			return nil, errors.New("unsupported object parameter")
+		case "array":
+			if param.Items == nil && param.Items.Type == "" {
+				return nil, errors.New("array item is empty")
+			}
+
+			itemName := getScalarFromType(oc.schema, []string{param.Items.Type}, param.Format, param.Enum, oc.trimPathPrefix(apiPath), fieldPaths)
+			result = schema.NewArrayType(schema.NewNamedType(itemName))
+
+		default:
+			return nil, fmt.Errorf("unsupported schema type %s", param.Type)
 		}
-
-		itemName := getScalarFromType(oc.schema, param.Items.Type, param.Enum, oc.trimPathPrefix(apiPath), fieldPaths)
-		result = schema.NewArrayType(schema.NewNamedType(itemName))
-
-	default:
-		return nil, fmt.Errorf("unsupported schema type %s", param.Type)
 	}
 
 	if param.Required == nil || !*param.Required {
@@ -432,7 +485,7 @@ func (oc *openAPIv2Converter) getSchemaType(typeSchema *base.Schema, apiPath str
 	if typeSchema == nil {
 		return nil, errParameterSchemaEmpty
 	}
-	if len(typeSchema.AnyOf) > 0 || typeSchema.AdditionalProperties != nil {
+	if len(typeSchema.AnyOf) > 0 || typeSchema.AdditionalProperties != nil || len(typeSchema.Type) > 1 {
 		scalarName := "JSON"
 		if _, ok := oc.schema.ScalarTypes[scalarName]; !ok {
 			oc.schema.ScalarTypes[scalarName] = *schema.NewScalarType()
@@ -446,67 +499,69 @@ func (oc *openAPIv2Converter) getSchemaType(typeSchema *base.Schema, apiPath str
 
 	var result schema.TypeEncoder
 	typeName := typeSchema.Type[0]
-	switch typeName {
-	case "boolean", "integer", "number", "string":
-		scalarName := getScalarFromType(oc.schema, typeName, typeSchema.Enum, oc.trimPathPrefix(apiPath), fieldPaths)
+	if isPrimitiveScalar(typeName) {
+		scalarName := getScalarFromType(oc.schema, typeSchema.Type, typeSchema.Format, typeSchema.Enum, oc.trimPathPrefix(apiPath), fieldPaths)
 		result = schema.NewNamedType(scalarName)
-	// case "null":
-	case "object":
-		refName := utils.StringSliceToPascalCase(fieldPaths)
+	} else {
 
-		if typeSchema.Properties == nil || typeSchema.Properties.IsZero() {
-			// treat no-property objects as a JSON scalar
-			oc.schema.ScalarTypes[refName] = *schema.NewScalarType()
-		} else {
-			object := schema.ObjectType{
-				Fields: make(schema.ObjectTypeFields),
-			}
-			if typeSchema.Description != "" {
-				object.Description = &typeSchema.Description
-			}
-			for prop := typeSchema.Properties.First(); prop != nil; prop = prop.Next() {
-				propName := prop.Key()
-				propType, propApiSchema, err := oc.getSchemaTypeFromProxy(prop.Value(), !slices.Contains(typeSchema.Required, propName), apiPath, append(fieldPaths, propName))
-				if err != nil {
-					return nil, err
-				}
-				objField := schema.ObjectField{
-					Type: propType.Encode(),
-				}
-				if propApiSchema.Description != "" {
-					objField.Description = &propApiSchema.Description
-				}
-				object.Fields[propName] = objField
-			}
+		switch typeName {
+		case "object":
+			refName := utils.StringSliceToPascalCase(fieldPaths)
 
-			oc.schema.ObjectTypes[refName] = object
-		}
-		result = schema.NewNamedType(refName)
-	case "array":
-		if typeSchema.Items == nil || typeSchema.Items.A == nil {
-			return nil, errors.New("array item is empty")
-		}
-
-		itemName := getSchemaRefTypeNameV2(typeSchema.Items.A.GetReference())
-		if itemName != "" {
-			result = schema.NewArrayType(schema.NewNamedType(itemName))
-		} else {
-			itemSchemaA := typeSchema.Items.A.Schema()
-			if itemSchemaA != nil {
-				itemSchema, err := oc.getSchemaType(itemSchemaA, apiPath, fieldPaths)
-				if err != nil {
-					return nil, err
+			if typeSchema.Properties == nil || typeSchema.Properties.IsZero() {
+				// treat no-property objects as a JSON scalar
+				oc.schema.ScalarTypes[refName] = *schema.NewScalarType()
+			} else {
+				object := schema.ObjectType{
+					Fields: make(schema.ObjectTypeFields),
+				}
+				if typeSchema.Description != "" {
+					object.Description = &typeSchema.Description
+				}
+				for prop := typeSchema.Properties.First(); prop != nil; prop = prop.Next() {
+					propName := prop.Key()
+					propType, propApiSchema, err := oc.getSchemaTypeFromProxy(prop.Value(), !slices.Contains(typeSchema.Required, propName), apiPath, append(fieldPaths, propName))
+					if err != nil {
+						return nil, err
+					}
+					objField := schema.ObjectField{
+						Type: propType.Encode(),
+					}
+					if propApiSchema.Description != "" {
+						objField.Description = &propApiSchema.Description
+					}
+					object.Fields[propName] = objField
 				}
 
-				result = schema.NewArrayType(itemSchema)
+				oc.schema.ObjectTypes[refName] = object
 			}
-		}
+			result = schema.NewNamedType(refName)
+		case "array":
+			if typeSchema.Items == nil || typeSchema.Items.A == nil {
+				return nil, errors.New("array item is empty")
+			}
 
-		if result == nil {
-			return nil, fmt.Errorf("cannot parse type reference name: %s", typeSchema.Items.A.GetReference())
+			itemName := getSchemaRefTypeNameV2(typeSchema.Items.A.GetReference())
+			if itemName != "" {
+				result = schema.NewArrayType(schema.NewNamedType(itemName))
+			} else {
+				itemSchemaA := typeSchema.Items.A.Schema()
+				if itemSchemaA != nil {
+					itemSchema, err := oc.getSchemaType(itemSchemaA, apiPath, fieldPaths)
+					if err != nil {
+						return nil, err
+					}
+
+					result = schema.NewArrayType(itemSchema)
+				}
+			}
+
+			if result == nil {
+				return nil, fmt.Errorf("cannot parse type reference name: %s", typeSchema.Items.A.GetReference())
+			}
+		default:
+			return nil, fmt.Errorf("unsupported schema type %s", typeName)
 		}
-	default:
-		return nil, fmt.Errorf("unsupported schema type %s", typeName)
 	}
 
 	if typeSchema.Nullable != nil && *typeSchema.Nullable {

--- a/openapi/v2_test.go
+++ b/openapi/v2_test.go
@@ -17,6 +17,7 @@ func TestOpenAPIv2ToRESTSchema(t *testing.T) {
 		Options  *ConvertOptions
 		Expected string
 	}{
+		// go run . convert -f ./openapi/testdata/jsonplaceholder/swagger.json -o ./openapi/testdata/jsonplaceholder/expected.json --spec openapi2 --trim-prefix /v1
 		{
 			Name:     "jsonplaceholder",
 			Source:   "testdata/jsonplaceholder/swagger.json",
@@ -25,6 +26,7 @@ func TestOpenAPIv2ToRESTSchema(t *testing.T) {
 				TrimPrefix: "/v1",
 			},
 		},
+		// go run . convert -f ./openapi/testdata/petstore2/swagger.json -o ./openapi/testdata/petstore2/expected.json --spec openapi2
 		{
 			Name:     "petstore2",
 			Source:   "testdata/petstore2/swagger.json",

--- a/openapi/v3_test.go
+++ b/openapi/v3_test.go
@@ -18,6 +18,7 @@ func TestOpenAPIv3ToRESTSchema(t *testing.T) {
 		Source   string
 		Expected string
 	}{
+		// go run . convert -f ./openapi/testdata/petstore3/source.json -o ./openapi/testdata/petstore3/expected.json --spec openapi3 --env-prefix PET_STORE
 		{
 			Name:     "petstore3",
 			Source:   "testdata/petstore3/source.json",

--- a/schema/auth.go
+++ b/schema/auth.go
@@ -241,7 +241,7 @@ func (ss OAuthFlow) Validate(flowType OAuthFlowType) error {
 		if slices.Contains([]OAuthFlowType{ImplicitFlow, AuthorizationCodeFlow}, flowType) {
 			return fmt.Errorf("authorizationUrl is required for oauth2 %s security", flowType)
 		}
-	} else if _, err := parseHttpURL(ss.AuthorizationURL); err != nil {
+	} else if _, err := parseRelativeOrHttpURL(ss.AuthorizationURL); err != nil {
 		return fmt.Errorf("authorizationUrl: %s", err)
 	}
 
@@ -249,11 +249,11 @@ func (ss OAuthFlow) Validate(flowType OAuthFlowType) error {
 		if slices.Contains([]OAuthFlowType{PasswordFlow, ClientCredentialsFlow, AuthorizationCodeFlow}, flowType) {
 			return fmt.Errorf("tokenUrl is required for oauth2 %s security", flowType)
 		}
-	} else if _, err := parseHttpURL(ss.TokenURL); err != nil {
+	} else if _, err := parseRelativeOrHttpURL(ss.TokenURL); err != nil {
 		return fmt.Errorf("tokenUrl: %s", err)
 	}
 	if ss.RefreshURL != "" {
-		if _, err := parseHttpURL(ss.RefreshURL); err != nil {
+		if _, err := parseRelativeOrHttpURL(ss.RefreshURL); err != nil {
 			return fmt.Errorf("refreshUrl: %s", err)
 		}
 	}
@@ -294,7 +294,7 @@ func (ss OpenIDConfig) Validate() error {
 		return errors.New("openIdConnectUrl is required for oidc security")
 	}
 
-	if _, err := parseHttpURL(ss.OpenIDConnectURL); err != nil {
+	if _, err := parseRelativeOrHttpURL(ss.OpenIDConnectURL); err != nil {
 		return fmt.Errorf("openIdConnectUrl: %s", err)
 	}
 	return nil

--- a/schema/enum.go
+++ b/schema/enum.go
@@ -12,6 +12,8 @@ type SchemaSpecType string
 const (
 	OpenAPIv3Spec SchemaSpecType = "openapi3"
 	OpenAPIv2Spec SchemaSpecType = "openapi2"
+	OAS3Spec      SchemaSpecType = "oas3"
+	OAS2Spec      SchemaSpecType = "oas2"
 	NDCSpec       SchemaSpecType = "ndc"
 )
 
@@ -152,3 +154,34 @@ func ParseParameterLocation(input string) (ParameterLocation, error) {
 	}
 	return result, nil
 }
+
+// ScalarType defines supported scalar type enums of the OpenAPI spec
+type ScalarType string
+
+const (
+	ScalarTypeString   ScalarType = "String"
+	ScalarTypeInt      ScalarType = "Int"
+	ScalarTypeBigInt   ScalarType = "BigInt"
+	ScalarTypeFloat    ScalarType = "Float"
+	ScalarTypeBoolean  ScalarType = "Boolean"
+	ScalarTypeJSON     ScalarType = "JSON"
+	ScalarTypeDate     ScalarType = "Date"
+	ScalarTypeDateTime ScalarType = "DateTime"
+	ScalarTypeBase64   ScalarType = "Base64"
+	ScalarTypeUnixTime ScalarType = "UnixTime"
+	ScalarTypeEmail    ScalarType = "Email"
+	ScalarTypeUUID     ScalarType = "UUID"
+	ScalarTypeURI      ScalarType = "URI"
+	ScalarTypeIPV4     ScalarType = "ipv4"
+	ScalarTypeIPV6     ScalarType = "ipv6"
+)
+
+const (
+	ContentTypeHeader            = "Content-Type"
+	ContentTypeJSON              = "application/json"
+	ContentTypeXML               = "application/xml"
+	ContentTypeFormURLEncoded    = "application/x-www-form-urlencoded"
+	ContentTypeMultipartFormData = "multipart/form-data"
+	ContentTypeTextPlain         = "text/plain"
+	ContentTypeTextHTML          = "text/html"
+)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -101,24 +101,48 @@ type RequestParameter struct {
 // TypeSchema represents a serializable object of OpenAPI schema
 // that is used for validation
 type TypeSchema struct {
-	Type       string                `json:"type" yaml:"type" mapstructure:"type"`
-	Format     string                `json:"format,omitempty" yaml:"format,omitempty" mapstructure:"format"`
-	Pattern    string                `json:"pattern,omitempty" yaml:"pattern,omitempty" mapstructure:"pattern"`
-	Nullable   *bool                 `json:"nullable,omitempty" yaml:"nullable,omitempty" mapstructure:"nullable"`
-	Maximum    *float64              `json:"maximum,omitempty" yaml:"maximum,omitempty" mapstructure:"maximum"`
-	Minimum    *float64              `json:"minimum,omitempty," yaml:"minimum,omitempty" mapstructure:"minimum"`
-	MaxLength  *int64                `json:"maxLength,omitempty" yaml:"maxLength,omitempty" mapstructure:"maxLength"`
-	MinLength  *int64                `json:"minLength,omitempty" yaml:"minLength,omitempty" mapstructure:"minLength"`
-	Enum       []string              `json:"enum,omitempty" yaml:"enum,omitempty" mapstructure:"enum"`
-	Items      *TypeSchema           `json:"items,omitempty" yaml:"items,omitempty" mapstructure:"items"`
-	Properties map[string]TypeSchema `json:"properties,omitempty" yaml:"properties,omitempty" mapstructure:"properties"`
+	Type        string                `json:"type" yaml:"type" mapstructure:"type"`
+	Format      string                `json:"format,omitempty" yaml:"format,omitempty" mapstructure:"format"`
+	Pattern     string                `json:"pattern,omitempty" yaml:"pattern,omitempty" mapstructure:"pattern"`
+	Nullable    *bool                 `json:"nullable,omitempty" yaml:"nullable,omitempty" mapstructure:"nullable"`
+	Maximum     *float64              `json:"maximum,omitempty" yaml:"maximum,omitempty" mapstructure:"maximum"`
+	Minimum     *float64              `json:"minimum,omitempty," yaml:"minimum,omitempty" mapstructure:"minimum"`
+	MaxLength   *int64                `json:"maxLength,omitempty" yaml:"maxLength,omitempty" mapstructure:"maxLength"`
+	MinLength   *int64                `json:"minLength,omitempty" yaml:"minLength,omitempty" mapstructure:"minLength"`
+	Enum        []string              `json:"enum,omitempty" yaml:"enum,omitempty" mapstructure:"enum"`
+	Items       *TypeSchema           `json:"items,omitempty" yaml:"items,omitempty" mapstructure:"items"`
+	Properties  map[string]TypeSchema `json:"properties,omitempty" yaml:"properties,omitempty" mapstructure:"properties"`
+	Description string                `json:"-" yaml:"-"`
+}
+
+// RequestBodyEncoding represents the [Encoding Object] that contains serialization strategy for application/x-www-form-urlencoded
+//
+// [Encoding Object]: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#encoding-object
+type RequestBodyEncoding struct {
+	// Describes how a specific property value will be serialized depending on its type.
+	// See Parameter Object for details on the style property.
+	// The behavior follows the same values as query parameters, including default values.
+	// This property SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data.
+	// If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored
+	Style string `json:"style,omitempty" yaml:"style,omitempty" mapstructure:"style"`
+	// When this is true, property values of type array or object generate separate parameters for each value of the array, or key-value-pair of the map.
+	// For other types of properties this property has no effect. When style is form, the default value is true. For all other styles, the default value is false.
+	// This property SHALL be ignored if the request body media type is not application/x-www-form-urlencoded or multipart/form-data.
+	// If a value is explicitly defined, then the value of contentType (implicit or explicit) SHALL be ignored
+	Explode bool `json:"explode,omitempty" yaml:"explode,omitempty" mapstructure:"explode"`
+	// By default, reserved characters :/?#[]@!$&'()*+,;= in form field values within application/x-www-form-urlencoded bodies are percent-encoded when sent.
+	// AllowReserved allows these characters to be sent as is:
+	AllowReserved bool `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty" mapstructure:"allowReserved"`
+	// For more complex scenarios, such as nested arrays or JSON in form data, use the contentType keyword to specify the media type for encoding the value of a complex field.
+	ContentType string `json:"contentType,omitempty" yaml:"contentType,omitempty" mapstructure:"contentType"`
 }
 
 // RequestBody defines flexible request body with content types
 type RequestBody struct {
-	Required    bool        `json:"required,omitempty" yaml:"required,omitempty" mapstructure:"required"`
-	ContentType string      `json:"contentType,omitempty" yaml:"contentType,omitempty" mapstructure:"contentType"`
-	Schema      *TypeSchema `json:"schema,omitempty" yaml:"schema,omitempty" mapstructure:"schema"`
+	Required    bool                           `json:"required,omitempty" yaml:"required,omitempty" mapstructure:"required"`
+	ContentType string                         `json:"contentType,omitempty" yaml:"contentType,omitempty" mapstructure:"contentType"`
+	Schema      *TypeSchema                    `json:"schema,omitempty" yaml:"schema,omitempty" mapstructure:"schema"`
+	Encoding    map[string]RequestBodyEncoding `json:"encoding,omitempty" yaml:"encoding,omitempty" mapstructure:"encoding"`
 }
 
 // RESTFunctionInfo extends NDC query function with OpenAPI REST information

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -70,19 +70,23 @@ type Request struct {
 	Parameters []RequestParameter `json:"parameters,omitempty" yaml:"parameters,omitempty" mapstructure:"parameters"`
 	Security   AuthSecurities     `json:"security,omitempty" yaml:"security,omitempty" mapstructure:"security"`
 	// configure the request timeout in seconds, default 30s
-	Timeout uint `json:"timeout,omitempty" yaml:"timeout,omitempty" mapstructure:"timeout"`
+	Timeout     uint           `json:"timeout,omitempty" yaml:"timeout,omitempty" mapstructure:"timeout"`
+	Servers     []ServerConfig `json:"servers,omitempty" yaml:"servers,omitempty" mapstructure:"servers"`
+	RequestBody *RequestBody   `json:"requestBody,omitempty" yaml:"requestBody,omitempty" mapstructure:"requestBody"`
 }
 
 // Clone copies this instance to a new one
 func (r Request) Clone() *Request {
 	return &Request{
-		URL:        r.URL,
-		Method:     r.Method,
-		Type:       r.Type,
-		Headers:    r.Headers,
-		Parameters: r.Parameters,
-		Timeout:    r.Timeout,
-		Security:   r.Security,
+		URL:         r.URL,
+		Method:      r.Method,
+		Type:        r.Type,
+		Headers:     r.Headers,
+		Parameters:  r.Parameters,
+		Timeout:     r.Timeout,
+		Security:    r.Security,
+		Servers:     r.Servers,
+		RequestBody: r.RequestBody,
 	}
 }
 
@@ -108,6 +112,13 @@ type TypeSchema struct {
 	Enum       []string              `json:"enum,omitempty" yaml:"enum,omitempty" mapstructure:"enum"`
 	Items      *TypeSchema           `json:"items,omitempty" yaml:"items,omitempty" mapstructure:"items"`
 	Properties map[string]TypeSchema `json:"properties,omitempty" yaml:"properties,omitempty" mapstructure:"properties"`
+}
+
+// RequestBody defines flexible request body with content types
+type RequestBody struct {
+	Required    bool        `json:"required,omitempty" yaml:"required,omitempty" mapstructure:"required"`
+	ContentType string      `json:"contentType,omitempty" yaml:"contentType,omitempty" mapstructure:"contentType"`
+	Schema      *TypeSchema `json:"schema,omitempty" yaml:"schema,omitempty" mapstructure:"schema"`
 }
 
 // RESTFunctionInfo extends NDC query function with OpenAPI REST information

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -61,6 +61,7 @@ func TestDecodeRESTProcedureInfo(t *testing.T) {
 				t.FailNow()
 			}
 			assertDeepEqual(t, tc.expected, procedure)
+			assertDeepEqual(t, tc.expected.Request.Clone(), procedure.Request.Clone())
 		})
 	}
 }
@@ -136,12 +137,14 @@ func TestDecodeRESTFunctionInfo(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var procedure RESTFunctionInfo
-			if err := json.Unmarshal([]byte(tc.raw), &procedure); err != nil {
+			var fn RESTFunctionInfo
+			if err := json.Unmarshal([]byte(tc.raw), &fn); err != nil {
 				t.Errorf("failed to unmarshal: %s", err)
 				t.FailNow()
 			}
-			assertDeepEqual(t, tc.expected, procedure)
+			assertDeepEqual(t, tc.expected, fn)
+			assertDeepEqual(t, tc.expected.Request.Clone(), fn.Request.Clone())
+
 		})
 	}
 }

--- a/schema/setting.go
+++ b/schema/setting.go
@@ -86,3 +86,10 @@ func parseHttpURL(input string) (*url.URL, error) {
 
 	return url.Parse(input)
 }
+
+func parseRelativeOrHttpURL(input string) (*url.URL, error) {
+	if strings.HasPrefix(input, "/") {
+		return &url.URL{Path: input}, nil
+	}
+	return parseHttpURL(input)
+}


### PR DESCRIPTION
- Move the request body to a separate field `requestBody`
- Support more scalar variants from string and integer