### PR TITLE
Use arbitrary json for empty types and improve unused type cleanup logic

### DIFF
--- a/command/convert.go
+++ b/command/convert.go
@@ -21,6 +21,7 @@ type ConvertCommandArguments struct {
 	Output      string            `help:"The location where the ndc schema file will be generated. Print to stdout if not set" short:"o"`
 	Spec        string            `help:"The API specification of the file, is one of oas3 (openapi3), oas2 (openapi2)"`
 	Format      string            `help:"The output format, is one of json, yaml. If the output is set, automatically detect the format in the output file extension" default:"json"`
+	Strict      bool              `help:"Require strict validation" default:"false"`
 	Pure        bool              `help:"Return the pure NDC schema only" default:"false"`
 	TrimPrefix  string            `help:"Trim the prefix in URL, e.g. /v1"`
 	EnvPrefix   string            `help:"The environment variable prefix for security values, e.g. PET_STORE"`
@@ -42,6 +43,7 @@ func CommandConvertToNDCSchema(args *ConvertCommandArguments, logger *slog.Logge
 		slog.String("env_prefix", args.EnvPrefix),
 		slog.Any("patch_before", args.PatchBefore),
 		slog.Any("patch_after", args.PatchAfter),
+		slog.Bool("strict", args.Strict),
 		slog.Bool("pure", args.Pure),
 	)
 
@@ -127,6 +129,7 @@ type ConvertConfig struct {
 	TrimPrefix  string                `json:"trimPrefix" yaml:"trimPrefix"`
 	EnvPrefix   string                `json:"envPrefix" yaml:"envPrefix"`
 	Pure        bool                  `json:"pure" yaml:"pure"`
+	Strict      bool                  `json:"strict" yaml:"strict"`
 	PatchBefore []utils.PatchConfig   `json:"patchBefore" yaml:"patchBefore"`
 	PatchAfter  []utils.PatchConfig   `json:"patchAfter" yaml:"patchAfter"`
 	Output      string                `json:"output" yaml:"output"`
@@ -151,6 +154,7 @@ func ConvertToNDCSchema(config *ConvertConfig, logger *slog.Logger) (*schema.NDC
 		MethodAlias: config.MethodAlias,
 		TrimPrefix:  config.TrimPrefix,
 		EnvPrefix:   config.EnvPrefix,
+		Strict:      config.Strict,
 		Logger:      logger,
 	}
 	switch config.Spec {
@@ -192,6 +196,9 @@ func ResolveConvertConfigArguments(config *ConvertConfig, configDir string, args
 		}
 		if args.Pure {
 			config.Pure = args.Pure
+		}
+		if args.Strict {
+			config.Strict = args.Strict
 		}
 	}
 	if config.Spec == "" {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -26,6 +26,9 @@ spec: oas3
 
 # -- Return the pure NDC schema only
 pure: false
+
+# -- Require strict validation on empty types
+strict: false
 # -- Alias names for HTTP method. Used for prefix renaming, e.g. getUsers, postUser
 # methodAlias:
 #   get: get

--- a/openapi/internal/oas2_operation.go
+++ b/openapi/internal/oas2_operation.go
@@ -203,7 +203,7 @@ func (oc *oas2OperationBuilder) convertParameters(operation *v2.Operation, apiPa
 			return nil, err
 		}
 
-		oc.builder.typeUsageCounter.Increase(getNamedType(typeEncoder, true, ""))
+		oc.builder.typeUsageCounter.Add(getNamedType(typeEncoder, true, ""), 1)
 		schemaType := typeEncoder.Encode()
 		argument := schema.ArgumentInfo{
 			Type: schemaType,
@@ -240,7 +240,7 @@ func (oc *oas2OperationBuilder) convertParameters(operation *v2.Operation, apiPa
 	if len(formData.Properties) > 0 {
 		bodyName := fmt.Sprintf("%sBody", utils.StringSliceToPascalCase(fieldPaths))
 		oc.builder.schema.ObjectTypes[bodyName] = formDataObject
-		oc.builder.typeUsageCounter.Increase(bodyName)
+		oc.builder.typeUsageCounter.Add(bodyName, 1)
 
 		desc := fmt.Sprintf("Form data of %s", apiPath)
 		oc.Arguments["body"] = schema.ArgumentInfo{
@@ -279,7 +279,7 @@ func (oc *oas2OperationBuilder) convertResponse(responses *v2.Responses, apiPath
 	// return nullable boolean type if the response content is null
 	if resp == nil || resp.Schema == nil {
 		scalarName := string(rest.ScalarBoolean)
-		oc.builder.typeUsageCounter.Increase(scalarName)
+		oc.builder.typeUsageCounter.Add(scalarName, 1)
 		return schema.NewNullableNamedType(scalarName), nil
 	}
 
@@ -287,6 +287,6 @@ func (oc *oas2OperationBuilder) convertResponse(responses *v2.Responses, apiPath
 	if err != nil {
 		return nil, err
 	}
-	oc.builder.typeUsageCounter.Increase(getNamedType(schemaType, true, ""))
+	oc.builder.typeUsageCounter.Add(getNamedType(schemaType, true, ""), 1)
 	return schemaType, nil
 }

--- a/openapi/internal/oas3.go
+++ b/openapi/internal/oas3.go
@@ -267,7 +267,6 @@ func (oc *OAS3Builder) buildScalarJSON() *schema.NamedType {
 	if _, ok := oc.schema.ScalarTypes[scalarName]; !ok {
 		oc.schema.ScalarTypes[scalarName] = *defaultScalarTypes[rest.ScalarJSON]
 	}
-	oc.typeUsageCounter.Increase(scalarName)
 	return schema.NewNamedType(scalarName)
 }
 
@@ -319,8 +318,8 @@ func (oc *OAS3Builder) populateWriteSchemaType(schemaType schema.Type) (schema.T
 
 		writeName := formatWriteObjectName(ty.Name)
 		if _, ok := oc.schema.ObjectTypes[writeName]; ok {
-			oc.typeUsageCounter.Increase(writeName)
-			oc.typeUsageCounter.Decrease(ty.Name)
+			oc.typeUsageCounter.Add(writeName, 1)
+			oc.typeUsageCounter.Add(ty.Name, -1)
 			return schema.NewNamedType(writeName).Encode(), writeName, true
 		}
 		if evaluated {
@@ -349,8 +348,8 @@ func (oc *OAS3Builder) populateWriteSchemaType(schemaType schema.Type) (schema.T
 			}
 		}
 		if hasWriteField {
-			oc.typeUsageCounter.Increase(writeName)
-			oc.typeUsageCounter.Decrease(ty.Name)
+			oc.typeUsageCounter.Add(writeName, 1)
+			oc.typeUsageCounter.Add(ty.Name, -1)
 			oc.schema.ObjectTypes[writeName] = writeObject
 			return schema.NewNamedType(writeName).Encode(), writeName, true
 		}

--- a/openapi/internal/oas3_operation.go
+++ b/openapi/internal/oas3_operation.go
@@ -237,7 +237,7 @@ func (oc *oas3OperationBuilder) convertRequestBody(reqBody *v3.RequestBody, apiP
 		return nil, nil, nil
 	}
 
-	oc.builder.typeUsageCounter.Increase(getNamedType(schemaType, true, ""))
+	oc.builder.typeUsageCounter.Add(getNamedType(schemaType, true, ""), 1)
 	bodyResult := &rest.RequestBody{
 		ContentType: contentType,
 		Schema:      typeSchema,
@@ -301,7 +301,7 @@ func (oc *oas3OperationBuilder) convertRequestBody(reqBody *v3.RequestBody, apiP
 						EncodingObject: headerEncoding,
 					}
 
-					oc.builder.typeUsageCounter.Increase(getNamedType(ndcType, true, ""))
+					oc.builder.typeUsageCounter.Add(getNamedType(ndcType, true, ""), 1)
 					argument := schema.ArgumentInfo{
 						Type: ndcType.Encode(),
 					}
@@ -337,7 +337,7 @@ func (oc *oas3OperationBuilder) convertResponse(responses *v3.Responses, apiPath
 	// return nullable boolean type if the response content is null
 	if resp == nil || resp.Content == nil {
 		scalarName := string(rest.ScalarBoolean)
-		oc.builder.typeUsageCounter.Increase(scalarName)
+		oc.builder.typeUsageCounter.Add(scalarName, 1)
 		return schema.NewNullableNamedType(scalarName), nil
 	}
 	jsonContent, ok := resp.Content.Get("application/json")
@@ -350,6 +350,6 @@ func (oc *oas3OperationBuilder) convertResponse(responses *v3.Responses, apiPath
 	if err != nil {
 		return nil, err
 	}
-	oc.builder.typeUsageCounter.Increase(getNamedType(schemaType, true, ""))
+	oc.builder.typeUsageCounter.Add(getNamedType(schemaType, true, ""), 1)
 	return schemaType, nil
 }

--- a/openapi/internal/oas3_operation.go
+++ b/openapi/internal/oas3_operation.go
@@ -193,6 +193,7 @@ func (oc *oas3OperationBuilder) convertParameters(params []*v3.Parameter, apiPat
 			EncodingObject: encoding,
 		})
 
+		oc.builder.typeUsageCounter.Add(getNamedType(schemaType, true, ""), 1)
 		argument := schema.ArgumentInfo{
 			Type: schemaType.Encode(),
 		}

--- a/openapi/internal/types.go
+++ b/openapi/internal/types.go
@@ -113,6 +113,7 @@ type ConvertOptions struct {
 	MethodAlias map[string]string
 	TrimPrefix  string
 	EnvPrefix   string
+	Strict      bool
 	Logger      *slog.Logger
 }
 
@@ -120,20 +121,11 @@ type ConvertOptions struct {
 type TypeUsageCounter map[string]int
 
 // Increase increases the usage of an element
-func (tuc *TypeUsageCounter) Increase(name string) {
+func (tuc *TypeUsageCounter) Add(name string, value int) {
 	if counter, ok := (*tuc)[name]; ok {
-		(*tuc)[name] = counter + 1
+		(*tuc)[name] = counter + value
 	} else {
-		(*tuc)[name] = 1
-	}
-}
-
-// Decrease decreases the usage of an element
-func (tuc *TypeUsageCounter) Decrease(name string) {
-	if counter, ok := (*tuc)[name]; ok && counter > 1 {
-		(*tuc)[name] = counter - 1
-	} else {
-		(*tuc)[name] = 0
+		(*tuc)[name] = value
 	}
 }
 

--- a/openapi/internal/utils.go
+++ b/openapi/internal/utils.go
@@ -376,7 +376,7 @@ func cleanUnusedObjectType(schema *rest.NDCRestSchema, usageCounter *TypeUsageCo
 		if elemName == "" {
 			continue
 		}
-		usageCounter.Decrease(elemName)
+		usageCounter.Add(elemName, -1)
 		if usageCounter.Get(elemName) <= 0 {
 			cleanUnusedObjectType(schema, usageCounter, elemName)
 		}

--- a/openapi/testdata/onesignal/expected-patch.json
+++ b/openapi/testdata/onesignal/expected-patch.json
@@ -133,11 +133,6 @@
         "type": "enum"
       }
     },
-    "Float64": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": { "type": "float64" }
-    },
     "Int32": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -157,11 +152,6 @@
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": { "type": "json" }
-    },
-    "OperatorOperator": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": { "one_of": ["OR", "AND"], "type": "enum" }
     },
     "OutcomeDataAggregation": {
       "aggregate_functions": {},

--- a/openapi/testdata/onesignal/expected.json
+++ b/openapi/testdata/onesignal/expected.json
@@ -167,149 +167,6 @@
     }
   ],
   "object_types": {
-    "BasicNotification": {
-      "fields": {
-        "contents": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "StringMap",
-              "type": "named"
-            }
-          }
-        },
-        "custom_data": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "JSON",
-              "type": "named"
-            }
-          }
-        },
-        "data": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "JSON",
-              "type": "named"
-            }
-          }
-        },
-        "excluded_segments": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "String",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "filters": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "Filter",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "headings": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "StringMap",
-              "type": "named"
-            }
-          }
-        },
-        "id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          }
-        },
-        "include_player_ids": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "String",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "included_segments": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "String",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "subtitle": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "StringMap",
-              "type": "named"
-            }
-          }
-        },
-        "target_channel": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "PlayerNotificationTargetTargetChannel",
-              "type": "named"
-            }
-          }
-        }
-      }
-    },
-    "Button": {
-      "fields": {
-        "icon": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          }
-        },
-        "id": {
-          "type": {
-            "name": "String",
-            "type": "named"
-          }
-        },
-        "text": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          }
-        }
-      }
-    },
     "CancelNotificationSuccessResponse": {
       "fields": {
         "success": {
@@ -455,44 +312,6 @@
         }
       }
     },
-    "GenericError": {
-      "fields": {
-        "errors": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "GenericErrorErrors",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        }
-      }
-    },
-    "GenericErrorErrors": {
-      "fields": {
-        "code": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          }
-        },
-        "title": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          }
-        }
-      }
-    },
     "GetNotificationHistoryBody": {
       "fields": {
         "app_id": {
@@ -520,151 +339,6 @@
             "type": "nullable",
             "underlying_type": {
               "name": "NotificationsEvents",
-              "type": "named"
-            }
-          }
-        }
-      }
-    },
-    "InvalidIdentifierError": {
-      "fields": {
-        "invalid_external_user_ids": {
-          "description": "Returned if using include_external_user_ids",
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "String",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "invalid_player_ids": {
-          "description": "Returned if using include_player_ids and some were valid and others were not.",
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "String",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        }
-      }
-    },
-    "Notification": {
-      "fields": {
-        "contents": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "StringMap",
-              "type": "named"
-            }
-          }
-        },
-        "custom_data": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "JSON",
-              "type": "named"
-            }
-          }
-        },
-        "data": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "JSON",
-              "type": "named"
-            }
-          }
-        },
-        "excluded_segments": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "String",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "filters": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "Filter",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "headings": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "StringMap",
-              "type": "named"
-            }
-          }
-        },
-        "id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          }
-        },
-        "include_player_ids": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "String",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "included_segments": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "String",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "subtitle": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "StringMap",
-              "type": "named"
-            }
-          }
-        },
-        "target_channel": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "PlayerNotificationTargetTargetChannel",
               "type": "named"
             }
           }
@@ -743,55 +417,6 @@
             "type": "nullable",
             "underlying_type": {
               "name": "Int32",
-              "type": "named"
-            }
-          }
-        }
-      }
-    },
-    "NotificationTarget": {
-      "fields": {
-        "excluded_segments": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "String",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "include_player_ids": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "String",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "included_segments": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "String",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "target_channel": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "PlayerNotificationTargetTargetChannel",
               "type": "named"
             }
           }
@@ -1035,20 +660,6 @@
         }
       }
     },
-    "Operator": {
-      "fields": {
-        "operator": {
-          "description": "Strictly, this must be either `\"OR\"`, or `\"AND\"`.  It can be used to compose Filters as part of a Filters object.",
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "OperatorOperator",
-              "type": "named"
-            }
-          }
-        }
-      }
-    },
     "OutcomeData": {
       "fields": {
         "aggregation": {
@@ -1067,22 +678,6 @@
           "type": {
             "name": "Int32",
             "type": "named"
-          }
-        }
-      }
-    },
-    "OutcomesData": {
-      "fields": {
-        "outcomes": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "OutcomeData",
-                "type": "named"
-              },
-              "type": "array"
-            }
           }
         }
       }
@@ -1159,131 +754,6 @@
             "underlying_type": {
               "name": "DeliveryData",
               "type": "named"
-            }
-          }
-        }
-      }
-    },
-    "PlayerNotificationTarget": {
-      "fields": {
-        "include_player_ids": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "String",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "target_channel": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "PlayerNotificationTargetTargetChannel",
-              "type": "named"
-            }
-          }
-        }
-      }
-    },
-    "Purchase": {
-      "fields": {
-        "amount": {
-          "description": "The amount, in USD, spent purchasing the item.",
-          "type": {
-            "name": "String",
-            "type": "named"
-          }
-        },
-        "count": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "Float64",
-              "type": "named"
-            }
-          }
-        },
-        "iso": {
-          "description": "The 3-letter ISO 4217 currency code. Required for correct storage and conversion of amount.",
-          "type": {
-            "name": "String",
-            "type": "named"
-          }
-        },
-        "sku": {
-          "description": "The unique identifier of the purchased item.",
-          "type": {
-            "name": "String",
-            "type": "named"
-          }
-        }
-      }
-    },
-    "RateLimiterError": {
-      "fields": {
-        "errors": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "RateLimiterErrorErrors",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        }
-      }
-    },
-    "RateLimiterErrorErrors": {
-      "fields": {
-        "code": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          }
-        },
-        "title": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          }
-        }
-      }
-    },
-    "SegmentNotificationTarget": {
-      "fields": {
-        "excluded_segments": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "String",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "included_segments": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "String",
-                "type": "named"
-              },
-              "type": "array"
             }
           }
         }
@@ -1472,13 +942,6 @@
         "type": "enum"
       }
     },
-    "Float64": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "type": "float64"
-      }
-    },
     "Int32": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -1514,17 +977,6 @@
         "one_of": [
           "sent",
           "clicked"
-        ],
-        "type": "enum"
-      }
-    },
-    "OperatorOperator": {
-      "aggregate_functions": {},
-      "comparison_operators": {},
-      "representation": {
-        "one_of": [
-          "OR",
-          "AND"
         ],
         "type": "enum"
       }

--- a/openapi/testdata/petstore2/expected.json
+++ b/openapi/testdata/petstore2/expected.json
@@ -621,6 +621,15 @@
     },
     "SnakeObject": {
       "fields": {
+        "context": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "JSON",
+              "type": "named"
+            }
+          }
+        },
         "id": {
           "type": {
             "type": "nullable",

--- a/openapi/testdata/petstore2/swagger.json
+++ b/openapi/testdata/petstore2/swagger.json
@@ -799,7 +799,8 @@
       "type": "object",
       "properties": {
         "id": { "type": "integer", "format": "int64" },
-        "username": { "type": "string" }
+        "username": { "type": "string" },
+        "context": {}
       },
       "xml": { "name": "User" }
     },
@@ -857,7 +858,8 @@
           "$ref": "#/definitions/consentRequestSession"
         }
       }
-    }
+    },
+    "DefaultError": {}
   },
   "externalDocs": {
     "description": "Find out more about Swagger",

--- a/openapi/testdata/petstore3/expected.json
+++ b/openapi/testdata/petstore3/expected.json
@@ -430,51 +430,6 @@
         }
       }
     },
-    "Customer": {
-      "fields": {
-        "address": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "element_type": {
-                "name": "Address",
-                "type": "named"
-              },
-              "type": "array"
-            }
-          }
-        },
-        "id": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "Int64",
-              "type": "named"
-            }
-          }
-        },
-        "username": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "String",
-              "type": "named"
-            }
-          }
-        }
-      }
-    },
-    "Error": {
-      "description": "An error response from the Stripe API",
-      "fields": {
-        "error": {
-          "type": {
-            "name": "String",
-            "type": "named"
-          }
-        }
-      }
-    },
     "Order": {
       "fields": {
         "complete": {
@@ -3559,6 +3514,15 @@
           "type": {
             "name": "Boolean",
             "type": "named"
+          }
+        },
+        "context": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "JSON",
+              "type": "named"
+            }
           }
         },
         "created": {

--- a/openapi/testdata/petstore3/source.json
+++ b/openapi/testdata/petstore3/source.json
@@ -2997,6 +2997,7 @@
       "treasury.inbound_transfer": {
         "description": "Use [InboundTransfers](https://stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers) to add funds to your [FinancialAccount](https://stripe.com/docs/api#financial_accounts) via a PaymentMethod that is owned by you. The funds will be transferred via an ACH debit.",
         "properties": {
+          "context": {},
           "amount": {
             "description": "Amount (in cents) transferred.",
             "type": "integer"
@@ -3203,7 +3204,8 @@
         "title": "payment_method_affirm",
         "type": "object",
         "x-expandableFields": []
-      }
+      },
+      "DefaultError": {}
     },
     "requestBodies": {
       "Pet": {


### PR DESCRIPTION
- Consider using JSON scalar for empty types. Add the `--strict` flag if you want to strictly validate the OpenAPI document
- Improve unused type cleanup logic