### PR TITLE
upgrade ndc-sdk-go v1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/alecthomas/kong v0.9.0
 	github.com/evanphx/json-patch v0.5.2
-	github.com/hasura/ndc-sdk-go v1.2.5
+	github.com/hasura/ndc-sdk-go v1.3.0
 	github.com/invopop/jsonschema v0.12.0
 	github.com/lmittmann/tint v1.0.5
 	github.com/pb33f/libopenapi v0.16.14

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/hasura/ndc-sdk-go v1.2.5 h1:nsbOcX5Gx5CIPT3X6moRVhTFPvARKGrjJZNq5tg9HMI=
-github.com/hasura/ndc-sdk-go v1.2.5/go.mod h1:e1t6tWlONuvrnM38QGRl1UfiM7CDskvXSdguu2IwNpE=
+github.com/hasura/ndc-sdk-go v1.3.0 h1:xcL7hj0lPZXu9HntytlBe5pAAlCUTLqYAsPrltRUDbc=
+github.com/hasura/ndc-sdk-go v1.3.0/go.mod h1:ZY+jQ7H3H1DHNcS5KkqAOxvydSkz0VnRcibd4wLz9rw=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -120,8 +120,8 @@ golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
-golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
+golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/schema/enum_test.go
+++ b/schema/enum_test.go
@@ -10,7 +10,7 @@ func TestSchemaSpecType(t *testing.T) {
 	rawValue := "oas2"
 	var got SchemaSpecType
 	if err := json.Unmarshal([]byte(fmt.Sprintf(`"%s"`, rawValue)), &got); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	if got != SchemaSpecType(rawValue) {
 		t.Fatalf("expected %s, got: %s", rawValue, got)
@@ -24,7 +24,7 @@ func TestRequestType(t *testing.T) {
 	rawValue := "rest"
 	var got RequestType
 	if err := json.Unmarshal([]byte(fmt.Sprintf(`"%s"`, rawValue)), &got); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	if got != RequestType(rawValue) {
 		t.Fatalf("expected %s, got: %s", rawValue, got)
@@ -35,7 +35,7 @@ func TestSchemaFileFormat(t *testing.T) {
 	rawValue := "yaml"
 	var got SchemaFileFormat
 	if err := json.Unmarshal([]byte(fmt.Sprintf(`"%s"`, rawValue)), &got); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	if got != SchemaFileFormat(rawValue) {
 		t.Fatalf("expected %s, got: %s", rawValue, got)
@@ -49,7 +49,7 @@ func TestParameterLocation(t *testing.T) {
 	rawValue := "cookie"
 	var got ParameterLocation
 	if err := json.Unmarshal([]byte(fmt.Sprintf(`"%s"`, rawValue)), &got); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	if got != ParameterLocation(rawValue) {
 		t.Fatalf("expected %s, got: %s", rawValue, got)
@@ -63,7 +63,7 @@ func TestParameterEncodingStyle(t *testing.T) {
 	rawValue := "matrix"
 	var got ParameterEncodingStyle
 	if err := json.Unmarshal([]byte(fmt.Sprintf(`"%s"`, rawValue)), &got); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	if got != ParameterEncodingStyle(rawValue) {
 		t.Fatalf("expected %s, got: %s", rawValue, got)


### PR DESCRIPTION
Upgrade [ndc-sdk-go v1.3.0](https://github.com/hasura/ndc-sdk-go/releases/tag/v1.3.0)