### PR TITLE
fix: ignore operations that have 1xx and 3xx response codes

### DIFF
--- a/openapi/internal/utils.go
+++ b/openapi/internal/utils.go
@@ -405,3 +405,8 @@ func formatWriteObjectName(name string) string {
 func errParameterSchemaEmpty(fieldPaths []string) error {
 	return fmt.Errorf("parameter schema of $.%s is empty", strings.Join(fieldPaths, "."))
 }
+
+// redirection and information response status codes aren't supported
+func isUnsupportedResponseCodes[T int | int64](code T) bool {
+	return code < 200 || (code >= 300 && code < 400)
+}

--- a/openapi/testdata/petstore2/swagger.json
+++ b/openapi/testdata/petstore2/swagger.json
@@ -548,6 +548,14 @@
         "responses": { "default": { "description": "successful operation" } }
       }
     },
+    "/user/logout-redirect": {
+      "get": {
+        "operationId": "logoutUserRedirect",
+        "produces": [],
+        "parameters": [],
+        "responses": { "302": { "description": "successful operation" } }
+      }
+    },
     "/user": {
       "post": {
         "tags": ["user"],

--- a/openapi/testdata/petstore3/source.json
+++ b/openapi/testdata/petstore3/source.json
@@ -2756,6 +2756,19 @@
           }
         }
       }
+    },
+    "/self-service/browser/flows/logout": {
+      "get": {
+        "description": "This endpoint initializes a logout flow.\n\n\u003e This endpoint is NOT INTENDED for API clients and only works\nwith browsers (Chrome, Firefox, ...).\n\nOn successful logout, the browser will be redirected (HTTP 302 Found) to the `return_to` parameter of the initial request\nor fall back to `urls.default_return_to`.\n\nMore information can be found at [Ory Kratos User Logout Documentation](https://www.ory.sh/docs/next/kratos/self-service/flows/user-logout).",
+        "operationId": "initializeSelfServiceBrowserLogoutFlow",
+        "responses": {
+          "302": {
+            "$ref": "#/components/responses/emptyResponse"
+          }
+        },
+        "summary": "Initialize Browser-Based Logout User Flow",
+        "tags": ["public"]
+      }
     }
   },
   "components": {
@@ -3278,6 +3291,11 @@
             }
           }
         }
+      }
+    },
+    "responses": {
+      "emptyResponse": {
+        "description": "Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is\ntypically 201."
       }
     },
     "securitySchemes": {


### PR DESCRIPTION
Ignore operations that have `1xx` and `3xx` response codes. 